### PR TITLE
Bump snips-nlu-ontology to 0.61.2

### DIFF
--- a/hermes-ffi/Cargo.toml
+++ b/hermes-ffi/Cargo.toml
@@ -11,7 +11,7 @@ ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "e7a9649d
 hermes = { path = "../hermes" }
 lazy_static = { version="1.0" }
 libc = "0.2"
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.1" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.2" }
 env_logger = "0.5.10"
 
 [dev-dependencies]

--- a/hermes-inprocess/Cargo.toml
+++ b/hermes-inprocess/Cargo.toml
@@ -13,4 +13,4 @@ log = "0.4"
 
 [dev-dependencies]
 semver = "0.9"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.1" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.2" }

--- a/hermes-mqtt-ffi/Cargo.toml
+++ b/hermes-mqtt-ffi/Cargo.toml
@@ -19,4 +19,4 @@ hermes-ffi = { path = "../hermes-ffi" }
 hermes-mqtt = { path = "../hermes-mqtt" }
 libc = "0.2"
 log = "0.4"
-snips-nlu-ontology-ffi = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.1" }
+snips-nlu-ontology-ffi = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.2" }

--- a/hermes-mqtt/Cargo.toml
+++ b/hermes-mqtt/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "0.7", features = ["v4"] }
 [dev-dependencies]
 rand = "0.5"
 semver = "0.9"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.1" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.2" }
 
 [package.metadata.dinghy]
 ignored_rustc_triples = [

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 base64 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.1" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.61.2" }
 semver = { version = "0.9", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"

--- a/platforms/hermes-kotlin/build.gradle
+++ b/platforms/hermes-kotlin/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile "ai.snips:snips-nlu-ontology:0.61.1"
+    compile "ai.snips:snips-nlu-ontology:0.61.2"
     compile 'net.java.dev.jna:jna:4.5.0'
     compile 'org.parceler:parceler-api:1.1.9'
 }


### PR DESCRIPTION
This update of `snips-nlu-ontology` is **non breaking**.