### PR TITLE
adds C to Rust conversion function for IntentMessage. 

### DIFF
--- a/hermes-ffi/Cargo.toml
+++ b/hermes-ffi/Cargo.toml
@@ -23,3 +23,4 @@ env_logger = "0.6"
 
 [dev-dependencies]
 spectral = "0.6"
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }

--- a/hermes-ffi/Cargo.toml
+++ b/hermes-ffi/Cargo.toml
@@ -18,9 +18,9 @@ hermes = { path = "../hermes" }
 lazy_static = { version="1.0" }
 libc = "0.2"
 serde_json = { version = "1.0", optional = true }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
 env_logger = "0.6"
 
 [dev-dependencies]
 spectral = "0.6"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }

--- a/hermes-ffi/src/ontology/dialogue.rs
+++ b/hermes-ffi/src/ontology/dialogue.rs
@@ -1,7 +1,6 @@
 use std::ptr::null;
 use std::slice;
 
-use failure::bail;
 use failure::format_err;
 use failure::Fallible;
 use failure::ResultExt;

--- a/hermes-ffi/src/ontology/dialogue.rs
+++ b/hermes-ffi/src/ontology/dialogue.rs
@@ -64,29 +64,26 @@ impl CReprOf<hermes::IntentMessage> for CIntentMessage {
 
 impl AsRust<hermes::IntentMessage> for CIntentMessage {
     fn as_rust(&self) -> Fallible<hermes::IntentMessage> {
-        Ok(
-            hermes::IntentMessage {
-                session_id: create_rust_string_from!(self.session_id),
-                custom_data: create_optional_rust_string_from!(self.custom_data),
-                site_id: create_rust_string_from!(self.site_id),
-                input: create_rust_string_from!(self.input),
-                asr_tokens: if self.asr_tokens.is_null() {
-                    None
-                } else {
-                    Some(unsafe { &*self.asr_tokens }.as_rust()?)
-                },
-                asr_confidence: if self.asr_confidence >= 0.0 && self.asr_confidence <= 1.0 {
-                    Some(self.asr_confidence)
-                } else {
-                    None
-                },
-                intent: unsafe { &*self.intent }.as_rust()?,
-                slots: unsafe { &*self.slots }.as_rust()?,
-            }
-        )
+        Ok(hermes::IntentMessage {
+            session_id: create_rust_string_from!(self.session_id),
+            custom_data: create_optional_rust_string_from!(self.custom_data),
+            site_id: create_rust_string_from!(self.site_id),
+            input: create_rust_string_from!(self.input),
+            asr_tokens: if self.asr_tokens.is_null() {
+                None
+            } else {
+                Some(unsafe { &*self.asr_tokens }.as_rust()?)
+            },
+            asr_confidence: if self.asr_confidence >= 0.0 && self.asr_confidence <= 1.0 {
+                Some(self.asr_confidence)
+            } else {
+                None
+            },
+            intent: unsafe { &*self.intent }.as_rust()?,
+            slots: unsafe { &*self.slots }.as_rust()?,
+        })
     }
 }
-
 
 impl Drop for CIntentMessage {
     fn drop(&mut self) {
@@ -797,10 +794,9 @@ impl Drop for CDialogueConfigureMessage {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Range;
     use super::super::tests::round_trip_test;
     use super::*;
-
+    use std::ops::Range;
 
     #[test]
     fn round_trip_intent_not_recognized() {
@@ -1018,7 +1014,7 @@ mod tests {
                 entity: "entity".to_string(),
                 slot_name: "forecast_location".to_string(),
                 confidence_score: Some(0.8),
-            }
+            },
         };
 
         let asr_token_double_array = vec![

--- a/hermes-ffi/src/ontology/nlu.rs
+++ b/hermes-ffi/src/ontology/nlu.rs
@@ -5,7 +5,7 @@ use failure::bail;
 use failure::Fallible;
 use failure::ResultExt;
 use ffi_utils::*;
-use snips_nlu_ontology_ffi_macros::CSlot;
+use snips_nlu_ontology_ffi_macros::*;
 
 use crate::asr::CAsrTokenArray;
 
@@ -264,11 +264,9 @@ impl CReprOf<hermes::NluSlot> for CNluSlot {
 
 impl AsRust<hermes::NluSlot> for CNluSlot {
     fn as_rust(&self) -> Fallible<hermes::NluSlot> {
-        //hermes::NluSlot {
-        //confidence: self.confidence,
-        //nlu_slot: unimplemented!(),
-        //}
-        bail!("Missing converter for CSlot, if you need this feature, please tell us !")
+        Ok(hermes::NluSlot {
+            nlu_slot: unsafe {&*self.nlu_slot}.as_rust()?
+        })
     }
 }
 

--- a/hermes-ffi/src/ontology/nlu.rs
+++ b/hermes-ffi/src/ontology/nlu.rs
@@ -265,7 +265,7 @@ impl CReprOf<hermes::NluSlot> for CNluSlot {
 impl AsRust<hermes::NluSlot> for CNluSlot {
     fn as_rust(&self) -> Fallible<hermes::NluSlot> {
         Ok(hermes::NluSlot {
-            nlu_slot: unsafe {&*self.nlu_slot}.as_rust()?
+            nlu_slot: unsafe { &*self.nlu_slot }.as_rust()?,
         })
     }
 }

--- a/hermes-inprocess/Cargo.toml
+++ b/hermes-inprocess/Cargo.toml
@@ -13,4 +13,4 @@ log = "0.4"
 
 [dev-dependencies]
 semver = "0.9"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }

--- a/hermes-mqtt-ffi/Cargo.toml
+++ b/hermes-mqtt-ffi/Cargo.toml
@@ -21,6 +21,6 @@ hermes-ffi = { path = "../hermes-ffi" }
 hermes-mqtt = { path = "../hermes-mqtt" }
 libc = "0.2"
 log = "0.4"
-snips-nlu-ontology-ffi = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology-ffi = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
 # Needed to fix cbindgen issue. See https://github.com/eqrion/cbindgen/issues/221
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }

--- a/hermes-mqtt/Cargo.toml
+++ b/hermes-mqtt/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "0.7", features = ["v4"] }
 [dev-dependencies]
 rand = "0.6"
 semver = "0.9"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
 
 [package.metadata.dinghy]
 ignored_rustc_triples = [

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 base64 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
 semver = { version = "0.9", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"

--- a/platforms/hermes-kotlin/build.gradle
+++ b/platforms/hermes-kotlin/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile "ai.snips:snips-nlu-ontology:0.64.5"
+    compile "ai.snips:snips-nlu-ontology:0.64.6"
     compile 'net.java.dev.jna:jna:4.5.0'
     compile 'org.parceler:parceler-api:1.1.9'
 }


### PR DESCRIPTION
Hi there, 

In my quest to have full coverage for round-trip tests, I needed to implement conversion functions for `hermes` objects, from C to Rust objects. 

This P.R introduces conversion functions for `IntentMessage` and `Slot` structs, alongside with round-trip tests for this data structure. 

Would you mind reviewing ? 

Cheers. 