### PR TITLE
Hermes-Python 0.5.1

### DIFF
--- a/platforms/hermes-python/README.rst
+++ b/platforms/hermes-python/README.rst
@@ -55,7 +55,7 @@ Building from source
 If you want to use ``hermes-python`` on platforms that are not
 supported, you have to manually compile the wheel.
 
-You need to have *rust* installed :
+You need to have ``rust`` and ``cargo`` installed :
 
 ``curl https://sh.rustup.rs -sSf``
 
@@ -65,14 +65,6 @@ Clone, the ``hermes-protocol`` repository :
 
    git clone git@github.com:snipsco/hermes-protocol.git
    cd hermes-protocol
-
-You need to compile the dynamically linked shared object library :
-
-::
-
-   mkdir -p platforms/hermes-python/target
-   CARGO_TARGET_DIR=platforms/hermes-python/target cargo rustc --lib --manifest-path hermes-mqtt-ffi/Cargo.toml --release -- --crate-type cdylib
-   mv platforms/hermes-python/target/release/libhermes_mqtt_ffi.dylib platforms/hermes-python/hermes_python/dylib/
 
 You can then build the wheel :
 
@@ -86,6 +78,48 @@ The built wheels should be in ``platforms/hermes-python/dist``
 
 You can install those with pip : ``pip install
 platforms/hermes-python/dist/<your_wheel>.whl``
+
+
+Advanced wheel building
+***********************
+
+We define a new API for including pre-compiled shared objects when
+building a platform wheel.
+
+::
+
+   python setup.py bdist_wheel
+
+This command will compile the ``hermes-mqtt-ffi`` Rust extension, copy
+them to an appropriate location, and include them in the wheel.
+
+We introduce a new command-line argument : ``include-extension`` which
+is a way to include an already compiled (in previous steps)
+``hermes-mqtt-ffi`` extension in the wheel.
+
+Its usage is the following : ``include-extension=<default |
+the/path/to/your/extension.[so|dylib]>``
+
+For instance :
+
+::
+
+   python setup.py bdist_wheel --include-extension=default
+
+The default value for ``include-extension`` will look up for
+pre-compiled extension in the default paths (in
+``hermes-protocol/target/release/libhermes_mqtt_ffi.[dylib|so]`` and
+``hermes-protocol/platforms/hermes-python/hermes_python/dylib``).
+
+::
+
+   python setup.py bdist_wheel --include-extension=<the/path/to/your/extension.[so|dylib]>
+
+When doing x-compilation, you can also specify the target platform :
+
+::
+
+   python setup.py bdist_wheel --include-extension=<the/path/to/your/extension.[so|dylib]> --plat-name=<the_platform_tag>
 
 
 Tutorial

--- a/platforms/hermes-python/documentation/source/installation.rst
+++ b/platforms/hermes-python/documentation/source/installation.rst
@@ -13,7 +13,7 @@ Building from source
 
 If you want to use ``hermes-python`` on platforms that are not supported, you have to manually compile the wheel.
 
-You need to have `rust` installed :
+You need to have ``rust`` and ``cargo`` installed :
 
 ``curl https://sh.rustup.rs -sSf``
 
@@ -21,13 +21,6 @@ Clone, the ``hermes-protocol`` repository : ::
 
     git clone git@github.com:snipsco/hermes-protocol.git
     cd hermes-protocol
-
-You need to compile the dynamically linked shared object library : ::
-
-    mkdir -p platforms/hermes-python/target
-    CARGO_TARGET_DIR=platforms/hermes-python/target cargo rustc --lib --manifest-path hermes-mqtt-ffi/Cargo.toml --release -- --crate-type cdylib
-    mv platforms/hermes-python/target/release/libhermes_mqtt_ffi.dylib platforms/hermes-python/hermes_python/dylib/
-
 
 You can then build the wheel : ::
 

--- a/platforms/hermes-python/documentation/source/installation.rst
+++ b/platforms/hermes-python/documentation/source/installation.rst
@@ -32,3 +32,29 @@ The built wheels should be in ``platforms/hermes-python/dist``
 
 You can install those with pip : ``pip install platforms/hermes-python/dist/<your_wheel>.whl``
 
+Advanced wheel building
+=======================
+
+We define a new API for including pre-compiled shared objects when building a platform wheel. ::
+
+    python setup.py bdist_wheel
+
+This command will compile the ``hermes-mqtt-ffi`` Rust extension, copy them to an appropriate location, and include them in the wheel.
+
+We introduce a new command-line argument : ``include-extension`` which is a way to include an already compiled (in previous steps) ``hermes-mqtt-ffi`` extension in the wheel.
+
+Its usage is the following : ``include-extension=<default | the/path/to/your/extension.[so|dylib]>``
+
+For instance : ::
+
+    python setup.py bdist_wheel --include-extension=default
+
+The default value for ``include-extension`` will look up for pre-compiled extension in the default paths (in ``hermes-protocol/target/release/libhermes_mqtt_ffi.[dylib|so]`` and ``hermes-protocol/platforms/hermes-python/hermes_python/dylib``). ::
+
+    python setup.py bdist_wheel --include-extension=<the/path/to/your/extension.[so|dylib]>
+
+When doing x-compilation, you can also specify the target platform : ::
+
+    python setup.py bdist_wheel --include-extension=<the/path/to/your/extension.[so|dylib]> --plat-name=<the_platform_tag>
+
+

--- a/platforms/hermes-python/hermes_python/__version__.py
+++ b/platforms/hermes-python/hermes_python/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'hermes_python'
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __description__ = 'Python bindings for Snips Hermes Protocol'
 __url__ = {
     'Documentation': 'https://hermespython.readthedocs.io/en/latest/',

--- a/platforms/hermes-python/requirements/install.txt
+++ b/platforms/hermes-python/requirements/install.txt
@@ -1,1 +1,4 @@
-git+https://github.com/snipsco-forks/setuptools-rust.git@develop
+six
+future
+typing
+enum34

--- a/platforms/hermes-python/requirements/tests.txt
+++ b/platforms/hermes-python/requirements/tests.txt
@@ -1,3 +1,3 @@
--r install
+-r install.txt
 mock
 pytest

--- a/platforms/hermes-python/requirements/tests.txt
+++ b/platforms/hermes-python/requirements/tests.txt
@@ -1,7 +1,3 @@
+-r install
 mock
 pytest
-coverage
-pytest-cov
-future
-typing
-paho-mqtt

--- a/platforms/hermes-python/requirements/tests.txt
+++ b/platforms/hermes-python/requirements/tests.txt
@@ -1,3 +1,4 @@
 -r install.txt
 mock
 pytest
+paho-mqtt

--- a/platforms/hermes-python/run-tests-jenkins.sh
+++ b/platforms/hermes-python/run-tests-jenkins.sh
@@ -23,7 +23,6 @@ virtualenv --python=python2.7 env27
 source env27/bin/activate
 
 python setup.py bdist_wheel
-pip install . 
 pip install -r requirements/tests.txt
 py.test
 

--- a/platforms/hermes-python/run-tests-jenkins.sh
+++ b/platforms/hermes-python/run-tests-jenkins.sh
@@ -21,6 +21,7 @@ fi
 
 virtualenv --python=python2.7 env27
 source env27/bin/activate
+
 python setup.py bdist_wheel
 pip install . 
 pip install -r requirements/tests.txt

--- a/platforms/hermes-python/run-tests-travis.sh
+++ b/platforms/hermes-python/run-tests-travis.sh
@@ -13,17 +13,14 @@ fi
 
 mkdir -p tests/roundtrip/debug
 
-# The artifact were generated in a previous stage of the build
+# The artifacts were generated in a previous stage of the build
 # Let's copy them to appropriate locations
 
-cp ../../target/debug/libhermes_mqtt_ffi.so hermes_python/dylib
-cp ../../target/debug/libhermes_ffi_test.so tests/roundtrip/debug
-
+cp ../../target/debug/libhermes_ffi_test.dylib tests/roundtrip/debug
 
 virtualenv --python=python2.7 env27
 source env27/bin/activate 
-python setup.py bdist_wheel
-pip install . 
+python setup.py bdist_wheel --include-extension=default
 pip install -r requirements/tests.txt
 py.test 
 

--- a/platforms/hermes-python/run-tests-travis.sh
+++ b/platforms/hermes-python/run-tests-travis.sh
@@ -17,9 +17,9 @@ mkdir -p tests/roundtrip/debug
 # Let's copy them to appropriate locations
 
 if [[ $(uname) == "Linux" ]]; then 
-    cp ../../target/release/libhermes_ffi_test.so tests/roundtrip/debug
+    cp ../../target/debug/libhermes_ffi_test.so tests/roundtrip/debug
 elif [[ $(uname) == "Darwin" ]]; then
-    cp ../../target/release/libhermes_ffi_test.dylib tests/roundtrip/debug
+    cp ../../rarget/debug/libhermes_ffi_test.dylib tests/roundtrip/debug
 fi
 
 virtualenv --python=python2.7 env27

--- a/platforms/hermes-python/run-tests-travis.sh
+++ b/platforms/hermes-python/run-tests-travis.sh
@@ -16,7 +16,7 @@ mkdir -p tests/roundtrip/debug
 # The artifacts were generated in a previous stage of the build
 # Let's copy them to appropriate locations
 
-cp ../../target/debug/libhermes_ffi_test.dylib tests/roundtrip/debug
+cp ../../target/release/libhermes_ffi_test.dylib tests/roundtrip/debug
 
 virtualenv --python=python2.7 env27
 source env27/bin/activate 

--- a/platforms/hermes-python/run-tests-travis.sh
+++ b/platforms/hermes-python/run-tests-travis.sh
@@ -24,7 +24,7 @@ fi
 
 virtualenv --python=python2.7 env27
 source env27/bin/activate 
-python setup.py bdist_wheel --include-extension=default
+python setup.py bdist_wheel --include-extension=../../target/debug/libhermes_mqtt_ffi.so
 pip install -r requirements/tests.txt
 py.test 
 

--- a/platforms/hermes-python/run-tests-travis.sh
+++ b/platforms/hermes-python/run-tests-travis.sh
@@ -16,7 +16,11 @@ mkdir -p tests/roundtrip/debug
 # The artifacts were generated in a previous stage of the build
 # Let's copy them to appropriate locations
 
-cp ../../target/release/libhermes_ffi_test.dylib tests/roundtrip/debug
+if [[ $(uname) == "Linux" ]]; then 
+    cp ../../target/release/libhermes_ffi_test.so tests/roundtrip/debug
+elif [[ $(uname) == "Darwin" ]]; then
+    cp ../../target/release/libhermes_ffi_test.dylib tests/roundtrip/debug
+fi
 
 virtualenv --python=python2.7 env27
 source env27/bin/activate 

--- a/platforms/hermes-python/setup.py
+++ b/platforms/hermes-python/setup.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
-import colorama
 import io
 import os
 from setuptools import setup, find_packages
@@ -23,12 +22,12 @@ VERSION = "__version__.py"
 
 def log(level, msg):
     levels = {
-        'info': colorama.Fore.CYAN,
-        'warning': colorama.Fore.YELLOW,
-        'error': colorama.Fore.RED,
-        'success': colorama.Fore.GREEN
+        'info': '\033[36m',
+        'warning': '\033[33m',
+        'error': '\033[31m',
+        'success': '\033[32m'
     }
-    print(levels[level] + msg + colorama.Style.RESET_ALL)
+    print(levels[level] + msg + '\033[39m')
 
 class InstallPlatlib(install):
     def finalize_options(self):

--- a/platforms/hermes-python/setup.py
+++ b/platforms/hermes-python/setup.py
@@ -140,7 +140,7 @@ class bdist_wheel(_bdist_wheel, HermesExtension):
         _bdist_wheel.run(self)
 
     def get_tag(self):
-        return super(bdist_wheel, self).get_tag()
+        return _bdist_wheel.get_tag(self)
 
 
 with io.open(os.path.join(PACKAGE_PATH, VERSION), encoding="utf8") as f:

--- a/platforms/hermes-python/setup.py
+++ b/platforms/hermes-python/setup.py
@@ -153,6 +153,9 @@ with io.open(README, "rt", encoding="utf8") as f:
 with io.open(HISTORY, "rt", encoding="utf8") as f:
     history = f.read()
 
+with io.open(os.path.join(here, "requirements/install.txt")) as f:
+    install_requires = f.read().strip().split('\n')
+
 packages = [p for p in find_packages() if "tests" not in p]
 
 extras_require = {
@@ -179,7 +182,7 @@ setup(
     download_url='',
     license='MIT',
     keywords=['snips'],
-    install_requires=['six', 'future', 'typing', 'enum34'],
+    install_requires=install_requires,
     test_suite="tests",
     extras_require=extras_require,
     packages=packages,
@@ -199,3 +202,4 @@ setup(
     zip_safe=False,
     include_package_data=True,
 )
+

--- a/platforms/hermes-python/setup.py
+++ b/platforms/hermes-python/setup.py
@@ -113,12 +113,11 @@ class HermesExtension(Command):
                 log("success", "Done compiling hermes extension !")
                 self.include_extension = BUILT_SHARED_OBJECT_PATH
 
-        log("error", "about to look into : {}".format(self.include_extension))
         if os.path.samefile(self.include_extension, self.DYLIB_PATH):
             log("error", "got here")
-            shutil.copy(self.include_extension, self.DYLIB_PATH)
+        
+	shutil.copy(self.include_extension, self.DYLIB_PATH)
         log("success", "Copied {} -> {}".format(self.include_extension, self.DYLIB_PATH))
-
         log("warning", 10 * "=" + " End of Compiling Hermes Extension Step " + 10 * "=")
 
 

--- a/platforms/hermes-python/setup.py
+++ b/platforms/hermes-python/setup.py
@@ -1,12 +1,14 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
+import colorama
 import io
 import os
 from setuptools import setup, find_packages
 import sys
 import subprocess
 import shutil
+from setuptools import Command
 
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 from setuptools.command.install import install
@@ -18,39 +20,125 @@ README = os.path.join(here, "README.rst")
 HISTORY = os.path.join(here, "documentation/source/HISTORY.rst")
 VERSION = "__version__.py"
 
-DYLIB_PATH = os.path.join(PACKAGE_PATH, "dylib")
-SHARED_OBJECT_FILENAME = "libhermes_mqtt_ffi"
-SHARED_OBJECT_EXTENSION = ".dylib" if sys.platform.startswith("darwin") else ".so"
-SHARED_OBJECT_PATH = os.path.join(DYLIB_PATH, SHARED_OBJECT_FILENAME + SHARED_OBJECT_EXTENSION)
 
+def log(level, msg):
+    levels = {
+        'info': colorama.Fore.CYAN,
+        'warning': colorama.Fore.YELLOW,
+        'error': colorama.Fore.RED,
+        'success': colorama.Fore.GREEN
+    }
+    print(levels[level] + msg + colorama.Style.RESET_ALL)
 
 class InstallPlatlib(install):
     def finalize_options(self):
         install.finalize_options(self)
         self.install_lib = self.install_platlib
 
+class HermesExtension(Command):
+    DYLIB_PATH = os.path.join(PACKAGE_PATH, "dylib")
+    SHARED_OBJECT_FILENAME = "libhermes_mqtt_ffi"
+    SHARED_OBJECT_EXTENSION = ".dylib" if sys.platform.startswith("darwin") else ".so"
+    SHARED_OBJECT_PATH = os.path.join(DYLIB_PATH, SHARED_OBJECT_FILENAME + SHARED_OBJECT_EXTENSION)
+
+    description = "Builds the compiled extension hermes-mqtt-ffi required by hermes-python." \
+                  "or includes an already compiled extension if the path to the latter is provided. " \
+                  "\n" \
+                  "Requires cargo + rust to be installed : \n" \
+                  "=> please visit : https://www.rustup.rs"
+
+    user_options = [
+        ('include-extension=', None,
+         'path to the compiled Hermes extension. If provided, it will not build the extension'),
+    ]
+
+    BUILD_HERMES_EXTENSION_COMMAND = ["cargo", "build", "-p", "hermes-mqtt-ffi", "--release"]
+
+
+    def initialize_options(self):
+        log("info", "preparing hermes extension building step")
+        self.include_extension = None
+
+    def finalize_options(self):
+        if self.include_extension:  # Try to include an pre-compiled hermes extension.
+            if self.include_extension == "default":  # We look in the default places :
+                log("warning",
+                    "assuming the extension is pre-compiled. Will look up for the extensions in default paths. ")
+                if not os.path.exists(self.SHARED_OBJECT_PATH):  # if not in hermes_python/dylib/
+                    log('error', "Did not find compiled extension in : {}".format(self.SHARED_OBJECT_PATH))
+
+                    BUILT_SHARED_OBJECT_PATH = os.path.join(
+                        os.path.normpath(os.path.join(here, "../..")),
+                        "target/release/{}{}".format(self.SHARED_OBJECT_FILENAME, self.SHARED_OBJECT_EXTENSION)
+                    )
+
+                    if not os.path.exists(BUILT_SHARED_OBJECT_PATH):  # if not in ../../target/release/
+                        log("error", "Did not find compiled extensions under : {}".format(
+                            BUILT_SHARED_OBJECT_PATH))
+                        raise Exception("Could not find any pre-compiled hermes extension in : {} nor {} ..."
+                                        "The commands you previously ran, did not output compiled extensions."
+                                        "You can build extensions with the command : '{}'"
+                                        .format(self.SHARED_OBJECT_PATH,
+                                                BUILT_SHARED_OBJECT_PATH,
+                                                " ".join(self.BUILD_HERMES_EXTENSION_COMMAND)))
+                    else:
+                        log("success", "Found extension at : {}".format(BUILT_SHARED_OBJECT_PATH))
+                        self.include_extension = BUILT_SHARED_OBJECT_PATH
+                else:
+                    log("success", "Found extension at : {}".format(self.SHARED_OBJECT_PATH))
+                    self.include_extension = self.SHARED_OBJECT_PATH
+
+            else:
+                if not os.path.exists(self.include_extension):  # We check that the provided extension exists
+                    raise Exception("the provided path to the compiled extension : {} doesn't exists ...")
+
+            self.include_extension = os.path.normpath(self.include_extension)
+        else:
+            log("warning", "No path to pre-compiled extension provided. "
+                           "Proceeding to compile the extension in release mode.")
+
     def run(self):
-        BUILT_SHARED_OBJECT_PATH = os.path.join(
-            os.path.normpath(os.path.join(here, "../..")),
-            "target/release/{}{}".format(SHARED_OBJECT_FILENAME, SHARED_OBJECT_EXTENSION)
-        )
+        log("warning", 10 * "=" + " Compiling Hermes Extension Step " + 10 * "=")
 
-        if not os.path.exists(SHARED_OBJECT_PATH):
-            if not os.path.exists(BUILT_SHARED_OBJECT_PATH):
-                return_code = subprocess.call(["cargo", "build", "-p", "hermes-mqtt-ffi", "--release"])
-                if return_code > 0:
-                    raise Exception("Could not compile C bindings")
+        if not self.include_extension:
+            return_code = subprocess.call(["cargo", "build", "-p", "hermes-mqtt-ffi", "--release"])
+            if return_code > 0:
+                raise Exception("Could not compile C bindings, the command : '{}' "
+                                "exited with a non-zero error code ... "
+                                .format(" ".join(self.BUILD_HERMES_EXTENSION_COMMAND)))
+            else:
+                BUILT_SHARED_OBJECT_PATH = os.path.join(
+                    os.path.normpath(os.path.join(here, "../..")),
+                    "target/release/{}{}".format(self.SHARED_OBJECT_FILENAME, self.SHARED_OBJECT_EXTENSION)
+                )
+                log("success", "Done compiling hermes extension !")
+                self.include_extension = BUILT_SHARED_OBJECT_PATH
 
-            shutil.copy(BUILT_SHARED_OBJECT_PATH, DYLIB_PATH)
+        log("error", "about to look into : {}".format(self.include_extension))
+        if os.path.samefile(self.include_extension, self.DYLIB_PATH):
+            log("error", "got here")
+            shutil.copy(self.include_extension, self.DYLIB_PATH)
+        log("success", "Copied {} -> {}".format(self.include_extension, self.DYLIB_PATH))
 
-        install.run(self)
+        log("warning", 10 * "=" + " End of Compiling Hermes Extension Step " + 10 * "=")
 
 
-class bdist_wheel(_bdist_wheel, object):
+class bdist_wheel(_bdist_wheel, HermesExtension):
+    user_options = _bdist_wheel.user_options + HermesExtension.user_options
+
+    def initialize_options(self):
+        HermesExtension.initialize_options(self)
+        _bdist_wheel.initialize_options(self)
+
     def finalize_options(self):
         _bdist_wheel.finalize_options(self)
+        HermesExtension.finalize_options(self)
         # noinspection PyAttributeOutsideInit
         self.root_is_pure = False
+
+    def run(self):
+        HermesExtension.run(self)
+        _bdist_wheel.run(self)
 
     def get_tag(self):
         return super(bdist_wheel, self).get_tag()
@@ -98,7 +186,8 @@ setup(
     packages=packages,
     cmdclass={
         'bdist_wheel': bdist_wheel,
-        'install': InstallPlatlib},
+        'install': InstallPlatlib,
+        'hermes_extension': HermesExtension},
     command_options={
         'documentation': {
             'project': ('setup.py', 'Hermes Python'),


### PR DESCRIPTION
This P.R brings major improvements to the way `hermes-python` is built. 
We define a new API for including pre-compiled shared objects when building a platform wheel. 

```
python setup.py bdist_wheel
```
This command will **compile** the Rust extension, copy them to an appropriate location, and include them in the wheel. 


We introduce a new command-line argument : `include-extension` which is a way to include an already compiled (in previous steps) `hermes-mqtt-ffi` extension in the wheel.

Its usage is the following : `include-extension=<default | the/path/to/your/extension.[so|dylib]>`

For instance : 

```
python setup.py bdist_wheel --include-extension=default
```
The `default` value for `include-extension` will look up for pre-compiled extension in the default paths (`hermes-protocol/target/release/libhermes_mqtt_ffi.[dylib|so]`). 

```
python setup.py bdist_wheel --include-extension=<the/path/to/your/extension.[so|dylib]>
```

When doing x-compilation, you can also specify the target platform : 

```
python setup.py bdist_wheel --include-extension=<the/path/to/your/extension.[so|dylib]> --plat-name=<the_platform_tag>
```