### PR TITLE
py/0.7.0

### DIFF
--- a/platforms/hermes-python/README.rst
+++ b/platforms/hermes-python/README.rst
@@ -485,6 +485,84 @@ end-user.
            .start()
 
 
+Dynamic Vocabulary using Entities Injection
+===========================================
+
+Please refer to the `official documentation
+<https://docs.snips.ai/articles/platform/nlu/dynamic-vocabulary>`_ for
+further information.
+
+Sometimes, you want to extend your voice assistant with new vocabulary
+it hasn’t seen when it was trained. For instance, let’s say that you
+have a bookstore voice assistant, that you update every week with new
+book titles that came out.
+
+The snips platform comes with the **Entities Injection** feature,
+which allows you to update both the ASR and the NLU models directly on
+the device to understand new vocabulary.
+
+Each intent within an assistant may contain some slots, and each slot
+has a specific type that we call an entity. If you have a book_title
+entity that contains a list of book titles in the inventory of your
+book store, Entities Injection lets you add new titles to this list.
+
+To inject new entity values, you have multiple operations at your
+disposal :
+
+* ``add`` adds the list of values that you provide to the existing
+   entity values.
+
+* ``addFromVanilla`` removes all the previously injected values to
+   the entity, and then, adds the list of values provided. Note that
+   the entity values coming from the console will be kept.
+
+Let’s see how an injection would be performed by the action code :
+
+::
+
+   from hermes_python.hermes import Hermes
+   from hermes_python.ontology.injection import InjectionRequestMessage, AddInjectionRequest, AddFromVanillaInjectionRequest
+
+   def retrieve_new_book_releases():
+       return ["The Half-Blood Prince", "The Deathly Hallows"]
+
+
+   def retrieve_book_inventory():
+       return ["The Philosopher's Stone", "The Chamber of Secrets", "The Prisoner of Azkaban", "The Goblet of Fire",
+               "The Order of the Phoenix", "The Half-Blood Prince", "The Deathly Hallows"]
+
+
+   # First example : We just add weekly releases
+
+   operations =  [
+       AddInjectionRequest({"book_titles" : retrieve_new_book_releases() }),
+   ]
+
+   request1 = InjectionRequestMessage(operations)
+
+   with Hermes("localhost:1883") as h:
+       h.request_injection(request1)
+
+
+   # Second example : We reset all the previously injected values of the book_title entity, and then, adds the list of values provided
+
+   operations =  [
+       AddInjectionRequest({"book_titles" : retrieve_book_inventory() }),
+   ]
+
+   request2 = InjectionRequestMessage(operations)
+
+   with Hermes("localhost:1883") as h:
+       h.request_injection(request2)
+
+**Careful**, performing an entity injection is a CPU and memory
+intensive task. You should not trigger multiple injection tasks at the
+same time on devices with limited computing power.
+
+You can monitor the progress of your injection request with
+``snips-watch -vvv``.
+
+
 Configuring MQTT options
 ========================
 

--- a/platforms/hermes-python/documentation/source/HISTORY.rst
+++ b/platforms/hermes-python/documentation/source/HISTORY.rst
@@ -1,6 +1,10 @@
 History
 ==========
 
+0.7.0 (2019-05-14)
+------------------
+* Introduces Entities Injection API.
+
 0.6.1 (2019-05-10)
 ------------------
 * Introduces `register_sound` API

--- a/platforms/hermes-python/documentation/source/tutorial.rst
+++ b/platforms/hermes-python/documentation/source/tutorial.rst
@@ -313,6 +313,72 @@ from the end-user.
             .start()
 
 
+Dynamic Vocabulary using Entities Injection
+-------------------------------------------
+
+Please refer to the `official documentation <https://docs.snips.ai/articles/platform/nlu/dynamic-vocabulary>`_ for further information.
+
+Sometimes, you want to extend your voice assistant with new vocabulary it hasn't seen when it was trained.
+For instance, let's say that you have a bookstore voice assistant, that you update every week with new book titles that came out.
+
+The snips platform comes with the **Entities Injection** feature, which allows you to update both the ASR and the NLU models
+directly on the device to understand new vocabulary.
+
+Each intent within an assistant may contain some slots, and each slot has a specific type that we call an entity.
+If you have a book_title entity that contains a list of book titles in the inventory of your book store,
+Entities Injection lets you add new titles to this list.
+
+To inject new entity values, you have multiple operations at your disposal :
+
+* ``add`` adds the list of values that you provide to the existing entity values.
+* ``addFromVanilla`` removes all the previously injected values to the entity, and then, adds the list of values provided. Note that the entity values coming from the console will be kept.
+
+Let's see how an injection would be performed by the action code :
+
+::
+
+    from hermes_python.hermes import Hermes
+    from hermes_python.ontology.injection import InjectionRequestMessage, AddInjectionRequest, AddFromVanillaInjectionRequest
+
+    def retrieve_new_book_releases():
+        return ["The Half-Blood Prince", "The Deathly Hallows"]
+
+
+    def retrieve_book_inventory():
+        return ["The Philosopher's Stone", "The Chamber of Secrets", "The Prisoner of Azkaban", "The Goblet of Fire",
+                "The Order of the Phoenix", "The Half-Blood Prince", "The Deathly Hallows"]
+
+
+    # First example : We just add weekly releases
+
+    operations =  [
+        AddInjectionRequest({"book_titles" : retrieve_new_book_releases() }),
+    ]
+
+    request1 = InjectionRequestMessage(operations)
+
+    with Hermes("localhost:1883") as h:
+        h.request_injection(request1)
+
+
+    # Second example : We reset all the previously injected values of the book_title entity, and then, adds the list of values provided
+
+    operations =  [
+        AddInjectionRequest({"book_titles" : retrieve_book_inventory() }),
+    ]
+
+    request2 = InjectionRequestMessage(operations)
+
+    with Hermes("localhost:1883") as h:
+        h.request_injection(request2)
+
+
+
+**Careful**, performing an entity injection is a CPU and memory intensive task. You should not trigger multiple injection
+tasks at the same time on devices with limited computing power.
+
+You can monitor the progress of your injection request with ``snips-watch -vvv``.
+
 
 Configuring MQTT options
 ------------------------

--- a/platforms/hermes-python/hermes_python/__version__.py
+++ b/platforms/hermes-python/hermes_python/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'hermes_python'
-__version__ = '0.6.1'
+_version__ = '0.7.0'
 __description__ = 'Python bindings for Snips Hermes Protocol'
 __url__ = {
     'Documentation': 'https://hermespython.readthedocs.io/en/latest/',

--- a/platforms/hermes-python/hermes_python/__version__.py
+++ b/platforms/hermes-python/hermes_python/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'hermes_python'
-_version__ = '0.7.0'
+__version__ = '0.7.0'
 __description__ = 'Python bindings for Snips Hermes Protocol'
 __url__ = {
     'Documentation': 'https://hermespython.readthedocs.io/en/latest/',

--- a/platforms/hermes-python/hermes_python/hermes.py
+++ b/platforms/hermes-python/hermes_python/hermes.py
@@ -312,42 +312,44 @@ class Hermes(object):
         self.ffi.tts.publish_register_sound(sound)
         return self
 
-    def subscribe_injection_status(self, injection_status_callback):
-        # type: (Callable[[Hermes, InjectionStatusMessage], None]) -> Hermes
-        """
-        Registers a callback that will be triggered after a injection status message was requested.
+    # This method is disabled as long as the injection API is stabilized
+    # def subscribe_injection_status(self, injection_status_callback):
+    #     # type: (Callable[[Hermes, InjectionStatusMessage], None]) -> Hermes
+    #     """
+    #     Registers a callback that will be triggered after a injection status message was requested.
+    #
+    #     Note that you have to request the status of the injection via the `request_injection_status` method of hermes.
+    #
+    #     The callback will be called with the following parameters :
+    #         - hermes: the current instance of the Hermes object
+    #         - injection_status : An object that gives you the date of the latest succesful injection.
+    #
+    #     :param injection_status_callback: the callback executed following a injection status request.
+    #     :return: the current instance of Hermes to allow chaining.
+    #     """
+    #     self.ffi.injection.register_subscribe_injection_status(
+    #         injection_status_callback,
+    #         self
+    #     )
+    #     return self
 
-        Note that you have to request the status of the injection via the `request_injection_status` method of hermes.
-
-        The callback will be called with the following parameters :
-            - hermes: the current instance of the Hermes object
-            - injection_status : An object that gives you the date of the latest succesful injection.
-
-        :param injection_status_callback: the callback executed following a injection status request.
-        :return: the current instance of Hermes to allow chaining.
-        """
-        self.ffi.injection.register_subscribe_injection_status(
-            injection_status_callback,
-            self
-        )
-        return self
-
-    def request_injection_status(self):
-        # type: () -> Hermes
-        """
-        Publishes a injection status request to the platform.
-
-        Note that this function is asynchronous, and that you retrieve the results of this call if you register a
-        callback with the `subscribe_injection_status` method.
-
-
-        :return: the current instance of Hermes to allow chaining.
-        """
-        self.ffi.injection.publish_injection_status_request()
-        return self
+    # This method is disabled as long as the injection API is stabilized
+    # def request_injection_status(self):
+    #     # type: () -> Hermes
+    #     """
+    #     Publishes a injection status request to the platform.
+    #
+    #     Note that this function is asynchronous, and that you retrieve the results of this call if you register a
+    #     callback with the `subscribe_injection_status` method.
+    #
+    #
+    #     :return: the current instance of Hermes to allow chaining.
+    #     """
+    #     self.ffi.injection.publish_injection_status_request()
+    #     return self
 
     def request_injection(self, injection_request):
-        # type: (InjectionRequestMessage) -> Hermes
+        # type: (InjectionRequest) -> Hermes
         """
         Publishes an injection request to the platform.
 

--- a/platforms/hermes-python/hermes_python/hermes.py
+++ b/platforms/hermes-python/hermes_python/hermes.py
@@ -349,7 +349,7 @@ class Hermes(object):
     #     return self
 
     def request_injection(self, injection_request):
-        # type: (InjectionRequest) -> Hermes
+        # type: (InjectionRequestMessage) -> Hermes
         """
         Publishes an injection request to the platform.
 

--- a/platforms/hermes-python/hermes_python/hermes.py
+++ b/platforms/hermes-python/hermes_python/hermes.py
@@ -13,6 +13,7 @@ from .ontology.dialogue import ContinueSessionMessage, EndSessionMessage, StartS
     DialogueConfiguration, IntentNotRecognizedMessage
 from .ontology.feedback import SiteMessage
 from .ontology.tts import RegisterSoundMessage
+from .ontology.injection import InjectionStatusMessage, InjectionRequestMessage
 from .api.ffi import FFI
 
 import threading
@@ -309,6 +310,55 @@ class Hermes(object):
         :return: the current instance of Hermes to allow chaining.
         """
         self.ffi.tts.publish_register_sound(sound)
+        return self
+
+    def subscribe_injection_status(self, injection_status_callback):
+        # type: (Callable[[Hermes, InjectionStatusMessage], None]) -> Hermes
+        """
+        Registers a callback that will be triggered after a injection status message was requested.
+
+        Note that you have to request the status of the injection via the `request_injection_status` method of hermes.
+
+        The callback will be called with the following parameters :
+            - hermes: the current instance of the Hermes object
+            - injection_status : An object that gives you the date of the latest succesful injection.
+
+        :param injection_status_callback: the callback executed following a injection status request.
+        :return: the current instance of Hermes to allow chaining.
+        """
+        self.ffi.injection.register_subscribe_injection_status(
+            injection_status_callback,
+            self
+        )
+        return self
+
+    def request_injection_status(self):
+        # type: () -> Hermes
+        """
+        Publishes a injection status request to the platform.
+
+        Note that this function is asynchronous, and that you retrieve the results of this call if you register a
+        callback with the `subscribe_injection_status` method.
+
+
+        :return: the current instance of Hermes to allow chaining.
+        """
+        self.ffi.injection.publish_injection_status_request()
+        return self
+
+    def request_injection(self, injection_request):
+        # type: (InjectionRequestMessage) -> Hermes
+        """
+        Publishes an injection request to the platform.
+
+        Note that this function is asynchronous. You can check the status of the injection by registering a injection
+        status callback with the `subscribe_injection_status` method of `hermes` and by requesting the status of the
+        injection with the `request_injection_status` method of `hermes`.
+
+        :param injection_request: An object that contains the different injection requests operations.
+        :return: the current instance of Hermes to allow chaining.
+        """
+        self.ffi.injection.publish_injection_request(injection_request)
         return self
 
     def start(self):

--- a/platforms/hermes-python/hermes_python/ontology/injection/__init__.py
+++ b/platforms/hermes-python/hermes_python/ontology/injection/__init__.py
@@ -2,7 +2,6 @@ from typing import Optional, Text, List, Mapping
 from ...ffi.ontology.injection import InjectionKind, CInjectionRequestMessage, CInjectionRequestOperation
 
 
-
 class InjectionStatusMessage(object):
     def __init__(self, last_injection_date):
         self.last_injection_date = last_injection_date
@@ -14,7 +13,7 @@ class InjectionStatusMessage(object):
 
 
 class InjectionRequestMessage(object):
-    def __init__(self, operations, lexicon, cross_language=None, id=None):
+    def __init__(self, operations, lexicon=dict(), cross_language=None, id=None):
         # type: (List[InjectionRequestOperation], Mapping[Text, List[Text]], Optional[Text], Optional[Text]) -> None
         self.operations = operations
         self.lexicon = lexicon
@@ -39,6 +38,11 @@ class InjectionRequestMessage(object):
 
     def into_c_repr(self):
         return CInjectionRequestMessage.from_repr(self)
+
+    @classmethod
+    def from_operations(cls, operations):
+        # type(List[InjectionRequestOperation]) -> InjectionRequestMessage
+        return cls(operations)
 
 
 class InjectionRequestOperation(object):

--- a/platforms/hermes-python/hermes_python/ontology/injection/__init__.py
+++ b/platforms/hermes-python/hermes_python/ontology/injection/__init__.py
@@ -14,7 +14,7 @@ class InjectionStatusMessage(object):
 
 class InjectionRequestMessage(object):
     def __init__(self, operations, lexicon=dict(), cross_language=None, id=None):
-        # type: (List[InjectionRequestOperation], Mapping[Text, List[Text]], Optional[Text], Optional[Text]) -> None
+         # type: (List[InjectionRequestOperation], Mapping[Text, List[Text]], Optional[Text], Optional[Text]) -> None
         self.operations = operations
         self.lexicon = lexicon
         self.cross_language = cross_language

--- a/platforms/hermes-python/hermes_python/ontology/injection/__init__.py
+++ b/platforms/hermes-python/hermes_python/ontology/injection/__init__.py
@@ -14,7 +14,7 @@ class InjectionStatusMessage(object):
 
 class InjectionRequestMessage(object):
     def __init__(self, operations, lexicon=dict(), cross_language=None, id=None):
-         # type: (List[InjectionRequestOperation], Mapping[Text, List[Text]], Optional[Text], Optional[Text]) -> None
+        # type: (List[InjectionRequestOperation], Mapping[Text, List[Text]], Optional[Text], Optional[Text]) -> None
         self.operations = operations
         self.lexicon = lexicon
         self.cross_language = cross_language
@@ -38,11 +38,6 @@ class InjectionRequestMessage(object):
 
     def into_c_repr(self):
         return CInjectionRequestMessage.from_repr(self)
-
-    @classmethod
-    def from_operations(cls, operations):
-        # type(List[InjectionRequestOperation]) -> InjectionRequestMessage
-        return cls(operations)
 
 
 class InjectionRequestOperation(object):

--- a/platforms/hermes-python/tests/test_hermes.py
+++ b/platforms/hermes-python/tests/test_hermes.py
@@ -5,6 +5,7 @@ import pytest
 from hermes_python.hermes import Hermes
 from hermes_python.ontology import MqttOptions
 from hermes_python.ontology.dialogue import StartSessionMessage, SessionInitNotification, ContinueSessionMessage
+from hermes_python.ontology.injection import InjectionRequestMessage
 
 HOST = "localhost"
 DUMMY_INTENT_NAME = "INTENT"
@@ -209,3 +210,38 @@ class TestContinueSession(object):
         continue_session_message = ContinueSessionMessage("session_id", "Tell me what the missing slot is", ["intent1"],
                                                           None, False, "missing_slot")
         h.ffi.dialogue.publish_continue_session.assert_called_once_with(continue_session_message)
+
+
+class TestInjection(object):
+    def test_requesting_injection_status(self):
+        h = Hermes(HOST)
+        h.ffi = mock.MagicMock()
+
+
+        with h:
+            h.request_injection_status()
+
+        h.ffi.injection.publish_injection_status_request.assert_called_once()
+
+    def test_correctly_subscribing_to_injection_status(self):
+        def injection_request_cb(callback, injection_status):
+            pass
+
+        h = Hermes(HOST)
+        h.ffi = mock.MagicMock()
+
+        with h:
+            h.subscribe_injection_status(injection_request_cb)
+
+        h.ffi.injection.register_subscribe_injection_status.assert_called_once_with(injection_request_cb, h)
+
+    def test_correctly_requesting_injection(self):
+        h = Hermes(HOST)
+        h.ffi = mock.MagicMock()
+
+        injection_request = InjectionRequestMessage([], dict())
+
+        with h:
+            h.request_injection(injection_request)
+
+        h.ffi.injection.publish_injection_request.assert_called_once_with(injection_request)

--- a/platforms/hermes-python/tests/test_hermes.py
+++ b/platforms/hermes-python/tests/test_hermes.py
@@ -213,27 +213,28 @@ class TestContinueSession(object):
 
 
 class TestInjection(object):
-    def test_requesting_injection_status(self):
-        h = Hermes(HOST)
-        h.ffi = mock.MagicMock()
-
-
-        with h:
-            h.request_injection_status()
-
-        h.ffi.injection.publish_injection_status_request.assert_called_once()
-
-    def test_correctly_subscribing_to_injection_status(self):
-        def injection_request_cb(callback, injection_status):
-            pass
-
-        h = Hermes(HOST)
-        h.ffi = mock.MagicMock()
-
-        with h:
-            h.subscribe_injection_status(injection_request_cb)
-
-        h.ffi.injection.register_subscribe_injection_status.assert_called_once_with(injection_request_cb, h)
+    # These tests are disabled as long as the injection API is stabilized.
+    # def test_requesting_injection_status(self):
+    #     h = Hermes(HOST)
+    #     h.ffi = mock.MagicMock()
+    #
+    #
+    #     with h:
+    #         h.request_injection_status()
+    #
+    #     h.ffi.injection.publish_injection_status_request.assert_called_once()
+    #
+    # def test_correctly_subscribing_to_injection_status(self):
+    #     def injection_request_cb(callback, injection_status):
+    #         pass
+    #
+    #     h = Hermes(HOST)
+    #     h.ffi = mock.MagicMock()
+    #
+    #     with h:
+    #         h.subscribe_injection_status(injection_request_cb)
+    #
+    #     h.ffi.injection.register_subscribe_injection_status.assert_called_once_with(injection_request_cb, h)
 
     def test_correctly_requesting_injection(self):
         h = Hermes(HOST)


### PR DESCRIPTION
Introduces a subset of the Entities Injection API. 

For now, we settled to remove the `publish_injection_status` and `subscribe_injection_status` method because the pattern to get injection status is a bit awkward for now. 

The removed methods will be re-introduced when the Injection facade offers callback when the injection is completed. 