### PR TITLE
js/0.3.9 + 0.3.10 + 0.3.11

### DIFF
--- a/platforms/hermes-javascript/.gitignore
+++ b/platforms/hermes-javascript/.gitignore
@@ -7,3 +7,4 @@ payloads
 /experiments.js
 libhermes_*.dylib
 /docs
+/types

--- a/platforms/hermes-javascript/CHANGELOG.md
+++ b/platforms/hermes-javascript/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.3.11](https://github.com/snipsco/hermes-protocol/compare/js/0.3.10...0.3.11) (2019-05-18)
+
+
+### Bug Fixes
+
+* **js:** prevent potential tiny memory leak ([d148945](https://github.com/snipsco/hermes-protocol/commit/d148945))
+
+
+
 ## [0.3.10](https://github.com/snipsco/hermes-protocol/compare/js/0.3.9...0.3.10) (2019-05-17)
 
 

--- a/platforms/hermes-javascript/CHANGELOG.md
+++ b/platforms/hermes-javascript/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.9](https://github.com/snipsco/hermes-protocol/compare/js/0.3.8...0.3.9) (2019-05-16)
+
+* **Chore**: Types and enums have their specific import location now: `import { /* ... */ } from 'hermes-javascript/type'`
+
+
 ## [0.3.8](https://github.com/snipsco/hermes-protocol/compare/js/0.3.7...0.3.8) (2019-05-14)
 
 

--- a/platforms/hermes-javascript/CHANGELOG.md
+++ b/platforms/hermes-javascript/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.3.10](https://github.com/snipsco/hermes-protocol/compare/js/0.3.9...0.3.10) (2019-05-17)
+
+
+### Bug Fixes
+
+* **dialog flow:** returning an object did not actually impact the message ([802d0b6](https://github.com/snipsco/hermes-protocol/commit/802d0b6))
+
+
+
 ## [0.3.9](https://github.com/snipsco/hermes-protocol/compare/js/0.3.8...0.3.9) (2019-05-16)
 
 * **Chore**: Types and enums have their specific import location now: `import { /* ... */ } from 'hermes-javascript/type'`

--- a/platforms/hermes-javascript/package-lock.json
+++ b/platforms/hermes-javascript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/platforms/hermes-javascript/package-lock.json
+++ b/platforms/hermes-javascript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/platforms/hermes-javascript/package-lock.json
+++ b/platforms/hermes-javascript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "hermes-mqtt-version": "0.64.3",
   "description": "Hermes javascript bindings",
   "keywords": [

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "hermes-mqtt-version": "0.64.3",
   "description": "Hermes javascript bindings",
   "keywords": [

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "hermes-mqtt-version": "0.64.3",
   "description": "Hermes javascript bindings",
   "keywords": [
@@ -34,8 +34,7 @@
     "test:mqtt:tls": "jest ./tests/mqtt/mqttTls.spec.ts",
     "test:roundtrip:json": "jest ./tests/roundtrips/roundtripJson.spec.ts",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1 --commit-path=. -t=js/",
-    "documentation": "typedoc --out docs --mode modules --external-modulemap  \".*(?:/src/api/types/|/src/)([\\w\\-_]+)/\" --excludeNotExported --excludePrivate --excludeProtected --excludeExternals --ignoreCompilerErrors src",
-    "prepare": "npm run build && npm run changelog"
+    "documentation": "typedoc --out docs --mode modules --external-modulemap  \".*(?:/src/api/types/|/src/)([\\w\\-_]+)/\" --excludeNotExported --excludePrivate --excludeProtected --excludeExternals --ignoreCompilerErrors src"
   },
   "engines": {
     "node": ">=10"

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -21,11 +21,12 @@
     "start": "npm run lint && npm run clean && npm run build && npm run test && npm run documentation",
     "lint": "eslint --ext .js,.ts src",
     "lint:fix": "eslint --ext .js,.ts --fix src",
-    "build": "npm run build:sources && npm run build:declarations",
+    "build": "npm run build:sources && npm run build:declarations && npm run build:types",
     "build:sources": "tsc",
     "build:declarations": "tsc -d --emitDeclarationOnly --allowJs false",
+    "build:types": "tsc -p tsconfig.types.json",
     "build:hermes": "node scripts/make.js",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf types",
     "postinstall": "node scripts/postinstall.js",
     "test": "npm run test:mqtt",
     "test:mqtt": "npm run test:roundtrip:json && npm run test:mqtt:json && npm run test:mqtt:tls",
@@ -43,6 +44,7 @@
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "dist",
+    "types",
     "scripts"
   ],
   "dependencies": {

--- a/platforms/hermes-javascript/src/api/ApiSubset.ts
+++ b/platforms/hermes-javascript/src/api/ApiSubset.ts
@@ -39,6 +39,7 @@ export default class ApiSubset {
     protected call: FFIFunctionCall
     public destroy() {}
     private listeners = new Map()
+    private ffiCallbacks = new Map()
     protected options: HermesOptions
     protected facade: Buffer | null = null
     protected subscribeEvents: { [key: string]: SubscribeEventDescriptor } = {}
@@ -93,7 +94,7 @@ export default class ApiSubset {
                 callback
             ]
             // Prevent GC
-            process.on('exit', function() { callback })
+            this.ffiCallbacks.set(eventName, callback)
             this.call(fullEventName, this.facade, ...args)
         }
         listeners.push(listener)

--- a/platforms/hermes-javascript/src/api/dialog/DialogFlow.ts
+++ b/platforms/hermes-javascript/src/api/dialog/DialogFlow.ts
@@ -72,6 +72,8 @@ export default class DialogFlow {
         let messageOptions: Partial<EndSessionMessage & ContinueSessionMessage> = {}
         if(typeof options === 'string') {
             messageOptions = { text: options }
+        } else if (typeof options === 'object') {
+            messageOptions = options
         }
         if(this.ended) {
             // End the session.

--- a/platforms/hermes-javascript/src/api/index.ts
+++ b/platforms/hermes-javascript/src/api/index.ts
@@ -19,7 +19,7 @@ export * from './types'
  * Hermes javascript is an high level API that allows you to
  * subscribe and send Snips messages using the Hermes protocol.
  *
- * **Important: do not instanciate this class more than once!**
+ * **Important: do not instantiate this class more than once!**
  */
 export class Hermes {
 
@@ -29,7 +29,7 @@ export class Hermes {
      * **Important: Each call to this function will open the hermes shared library
      * and bind hermes-javascript to it. It is an expensive operation.**
      *
-     * @param options - Options used to instanciate a new Hermes object.
+     * @param options - Options used to instantiate a new Hermes object.
      */
     constructor(options: HermesOptions = {}) {
 

--- a/platforms/hermes-javascript/src/api/types/index.ts
+++ b/platforms/hermes-javascript/src/api/types/index.ts
@@ -6,6 +6,9 @@ export * from './Feedback'
 export * from './Injection'
 export * from './Audio'
 export * from './Tts'
-
 export * from './enums'
 export * from './messages'
+
+import * as _enumerations from './enums'
+
+export const Enums = _enumerations

--- a/platforms/hermes-javascript/tsconfig.types.json
+++ b/platforms/hermes-javascript/tsconfig.types.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "target": "es6",
+        "noImplicitAny": false,
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "outDir": "types",
+        "declaration": true,
+        "allowJs": false,
+        "baseUrl": ".",
+        "strict": true,
+        "lib": ["es2017"]
+    },
+    "include": [
+        "src/api/types/**/*"
+    ]
+}


### PR DESCRIPTION
**0.3.11**

- fix(js): prevent potential tiny memory leak

**0.3.10**

- fix(dialog flow): returning an object did not actually impact the message

**0.3.9**

*Groundwork for [the toolkit](https://github.com/snipsco/snips-javascript-toolkit) package.*

- chore(build): Isolate and expose types and enums @ 'hermes-javascript/type'
