### PR TITLE
Compile and export FFI ontology only when the feature "structures" is enabled.

### DIFF
--- a/hermes-ffi/src/lib.rs
+++ b/hermes-ffi/src/lib.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "structures")]
 pub mod ontology;
 mod protocol_handler;
 
+#[cfg(feature = "structures")]
 pub use crate::ontology::*;
 pub use crate::protocol_handler::*;
 

--- a/hermes-ffi/src/ontology/dialogue.rs
+++ b/hermes-ffi/src/ontology/dialogue.rs
@@ -6,8 +6,8 @@ use failure::Fallible;
 use failure::ResultExt;
 use ffi_utils::*;
 
-use crate::asr::CAsrTokenDoubleArray;
-use crate::nlu::{CNluIntentClassifierResult, CNluSlotArray};
+use crate::ontology::asr::CAsrTokenDoubleArray;
+use crate::ontology::nlu::{CNluIntentClassifierResult, CNluSlotArray};
 
 #[repr(C)]
 #[derive(Debug)]

--- a/hermes-ffi/src/ontology/nlu.rs
+++ b/hermes-ffi/src/ontology/nlu.rs
@@ -7,7 +7,7 @@ use failure::ResultExt;
 use ffi_utils::*;
 use snips_nlu_ontology_ffi_macros::*;
 
-use crate::asr::CAsrTokenArray;
+use crate::ontology::asr::CAsrTokenArray;
 
 #[repr(C)]
 #[derive(Debug)]


### PR DESCRIPTION
We were compiling and exporting the FFI ontology even when we only enabled the "json" feature.