### PR TITLE
Fix NLU re-exporting symbols issues

### DIFF
--- a/hermes/src/ontology/nlu.rs
+++ b/hermes/src/ontology/nlu.rs
@@ -79,11 +79,6 @@ pub struct NluSlot {
     pub nlu_slot: snips_nlu_ontology::Slot,
 }
 
-pub use snips_nlu_ontology::{
-    AmountOfMoneyValue, DurationValue, InstantTimeValue, NumberValue, OrdinalValue, PercentageValue, Slot, SlotValue,
-    StringValue, TemperatureValue, TimeIntervalValue,
-};
-
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NluIntentClassifierResult {
@@ -109,3 +104,7 @@ pub struct NluIntentMessage {
 }
 
 impl<'de> HermesMessage<'de> for NluIntentMessage {}
+
+pub mod nlu_ontology {
+    pub use snips_nlu_ontology::*;
+}

--- a/hermes/src/ontology/nlu.rs
+++ b/hermes/src/ontology/nlu.rs
@@ -74,9 +74,15 @@ impl<'de> HermesMessage<'de> for NluIntentNotRecognizedMessage {}
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NluSlot {
+    //FIXME V2.0: Remove this redundant struct
     #[serde(flatten)]
     pub nlu_slot: snips_nlu_ontology::Slot,
 }
+
+pub use snips_nlu_ontology::{
+    AmountOfMoneyValue, DurationValue, InstantTimeValue, NumberValue, OrdinalValue, PercentageValue, Slot, SlotValue,
+    StringValue, TemperatureValue, TimeIntervalValue,
+};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
As of right now, it is mandatory to add as a dependency the `snips-nlu-ontology` crate to use some of the NLU ontology contained in the `NluIntentMessage` for example.

With this addition, the `hermes` crate is now exporting the ontology used by the structures exported by Hermes.