### PR TITLE
chore(npm): use ffi package from npm instead of github direct link

### DIFF
--- a/platforms/hermes-javascript/CHANGELOG.md
+++ b/platforms/hermes-javascript/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.3.13](https://github.com/snipsco/hermes-protocol/compare/js/0.3.12...0.3.13) (2019-07-18)
+
+
+### Features
+
+* **message:** add session ended component field on timeouts ([fb20157](https://github.com/snipsco/hermes-protocol/commit/fb20157))
+
+
+
 ## [0.3.12](https://github.com/snipsco/hermes-protocol/compare/js/0.3.11...0.3.12) (2019-06-17)
 
 

--- a/platforms/hermes-javascript/CHANGELOG.md
+++ b/platforms/hermes-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.14](https://github.com/snipsco/hermes-protocol/compare/js/0.3.13...0.3.14) (2019-07-18)
+
+* **Chore**: Bump hermes mqtt version to `0.67.0` ([8b4068f](https://github.com/snipsco/hermes-protocol/commit/8b4068f))
+
 ## [0.3.13](https://github.com/snipsco/hermes-protocol/compare/js/0.3.12...0.3.13) (2019-07-18)
 
 

--- a/platforms/hermes-javascript/package-lock.json
+++ b/platforms/hermes-javascript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/platforms/hermes-javascript/package-lock.json
+++ b/platforms/hermes-javascript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/platforms/hermes-javascript/package-lock.json
+++ b/platforms/hermes-javascript/package-lock.json
@@ -2475,12 +2475,13 @@
       }
     },
     "ffi": {
-      "version": "git+https://github.com/node-ffi/node-ffi.git#d9b843c03b35b99f205d001ebcbedd1b6c63b3d0",
-      "from": "git+https://github.com/node-ffi/node-ffi.git",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ffi/-/ffi-2.3.0.tgz",
+      "integrity": "sha512-vkPA9Hf9CVuQ5HeMZykYvrZF2QNJ/iKGLkyDkisBnoOOFeFXZQhUPxBARPBIZMJVulvBI2R+jgofW03gyPpJcQ==",
       "requires": {
         "bindings": "~1.2.0",
         "debug": "2",
-        "nan": "^2.12.0",
+        "nan": "2",
         "ref": "1",
         "ref-struct": "1"
       }

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "hermes-mqtt-version": "0.67.0",
   "description": "Hermes javascript bindings",
   "keywords": [

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-javascript",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "hermes-mqtt-version": "0.66.0",
   "description": "Hermes javascript bindings",
   "keywords": [

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-javascript",
   "version": "0.3.13",
-  "hermes-mqtt-version": "0.66.0",
+  "hermes-mqtt-version": "0.67.0",
   "description": "Hermes javascript bindings",
   "keywords": [
     "snips",

--- a/platforms/hermes-javascript/package.json
+++ b/platforms/hermes-javascript/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "chalk": "^2.4.2",
-    "ffi": "git+https://github.com/node-ffi/node-ffi.git",
+    "ffi": "^2.3.0",
     "node-fetch": "^2.6.0",
     "node-int64": "^0.4.0",
     "ref": "^1.3.5",


### PR DESCRIPTION
**node-ffi**: Update npm to point to the npm repository instead of the git branch.