### PR TITLE
Resurfacing identifiable component errors to snips-watch

### DIFF
--- a/hermes-inprocess/src/lib.rs
+++ b/hermes-inprocess/src/lib.rs
@@ -379,6 +379,10 @@ impl<T: Send + Sync + Debug + Copy + 'static> IdentifiableComponentFacade for In
         subscribe_filter!(self, IdentifiableComponentError<T> { error }, handler, site_id, |it| &it.site_id)
     }
 
+    fn subscribe_all_error(&self, handler: Callback<ErrorMessage>) -> Fallible<()> {
+        subscribe!(self, IdentifiableComponentError<T> { error }, handler)
+    }
+
     fn subscribe_component_loaded(
         &self,
         site_id: String,

--- a/hermes-inprocess/src/lib.rs
+++ b/hermes-inprocess/src/lib.rs
@@ -351,7 +351,7 @@ struct IdentifiableComponentVersion<T: Debug> {
 #[derive(Debug)]
 struct IdentifiableComponentError<T: Debug> {
     site_id: String,
-    error: ErrorMessage,
+    error: SiteErrorMessage,
     component: T,
 }
 
@@ -375,11 +375,11 @@ impl<T: Send + Sync + Debug + Copy + 'static> IdentifiableComponentFacade for In
         subscribe_filter!(self, IdentifiableComponentVersion<T> { version }, handler, site_id, |it| &it.site_id)
     }
 
-    fn subscribe_error(&self, site_id: String, handler: Callback<ErrorMessage>) -> Fallible<()> {
+    fn subscribe_error(&self, site_id: String, handler: Callback<SiteErrorMessage>) -> Fallible<()> {
         subscribe_filter!(self, IdentifiableComponentError<T> { error }, handler, site_id, |it| &it.site_id)
     }
 
-    fn subscribe_all_error(&self, handler: Callback<ErrorMessage>) -> Fallible<()> {
+    fn subscribe_all_error(&self, handler: Callback<SiteErrorMessage>) -> Fallible<()> {
         subscribe!(self, IdentifiableComponentError<T> { error }, handler)
     }
 
@@ -410,7 +410,7 @@ impl<T: Send + Sync + Debug + Copy + 'static> IdentifiableComponentBackendFacade
         self.publish(component_version)
     }
 
-    fn publish_error(&self, site_id: String, error: ErrorMessage) -> Fallible<()> {
+    fn publish_error(&self, site_id: String, error: SiteErrorMessage) -> Fallible<()> {
         let component_error: IdentifiableComponentError<T> = IdentifiableComponentError {
             site_id,
             error,

--- a/hermes-mqtt/src/lib.rs
+++ b/hermes-mqtt/src/lib.rs
@@ -415,6 +415,13 @@ macro_rules! impl_identifiable_component_facades_for {
                 )
             }
 
+            fn subscribe_all_error(&self, handler: Callback<ErrorMessage>) -> Fallible<()> {
+                self.mqtt_handler.subscribe_payload(
+                    &HermesTopic::Component(Some("+".to_string()), self.component, ComponentCommand::Error),
+                    move |p| handler.call(p),
+                )
+            }
+
             fn subscribe_component_loaded(
                 &self,
                 site_id: String,

--- a/hermes-mqtt/src/lib.rs
+++ b/hermes-mqtt/src/lib.rs
@@ -408,14 +408,14 @@ macro_rules! impl_identifiable_component_facades_for {
                 )
             }
 
-            fn subscribe_error(&self, site_id: String, handler: Callback<ErrorMessage>) -> Fallible<()> {
+            fn subscribe_error(&self, site_id: String, handler: Callback<SiteErrorMessage>) -> Fallible<()> {
                 self.mqtt_handler.subscribe_payload(
                     &HermesTopic::Component(Some(site_id), self.component, ComponentCommand::Error),
                     move |p| handler.call(p),
                 )
             }
 
-            fn subscribe_all_error(&self, handler: Callback<ErrorMessage>) -> Fallible<()> {
+            fn subscribe_all_error(&self, handler: Callback<SiteErrorMessage>) -> Fallible<()> {
                 self.mqtt_handler.subscribe_payload(
                     &HermesTopic::Component(Some("+".to_string()), self.component, ComponentCommand::Error),
                     move |p| handler.call(p),
@@ -456,7 +456,7 @@ macro_rules! impl_identifiable_component_facades_for {
                 )
             }
 
-            fn publish_error(&self, site_id: String, error: ErrorMessage) -> Fallible<()> {
+            fn publish_error(&self, site_id: String, error: SiteErrorMessage) -> Fallible<()> {
                 self.mqtt_handler.publish_payload(
                     &HermesTopic::Component(Some(site_id), self.component, ComponentCommand::Error),
                     error,

--- a/hermes-test-suite/src/lib.rs
+++ b/hermes-test-suite/src/lib.rs
@@ -296,8 +296,12 @@ macro_rules! t_identifiable_component {
                         $f.subscribe_version { "identifier".to_string() } <= VersionMessage | $f_back.publish_version
                         with VersionMessage { version: semver::Version { major: 1, minor: 0, patch: 0, pre: vec![], build: vec![]} };);
                 t!(error_works:
-                        $f.subscribe_error { "identifier".to_string() } <= ErrorMessage | $f_back.publish_error
-                        with ErrorMessage { session_id: Some("123abc".into()), error: "some error".into(), context: None };);
+                        $f.subscribe_error { "identifier".to_string() } <= SiteErrorMessage | $f_back.publish_error
+                        with SiteErrorMessage { session_id: Some("123abc".into()), error: "some error".into(), context: None, site_id: "identifier".into() };);
+                t!(all_error_works:
+                        ManyToOne
+                        $f.subscribe_all_error <= SiteErrorMessage | $f_back.publish_error { "identifier".into() }
+                        with SiteErrorMessage { session_id: Some("123abc".into()), error: "some error".into(), context: None, site_id: "identifier".into() };);
                 t!(component_loaded_works:
                         $f.subscribe_component_loaded { "identifier".to_string() } <= ComponentLoadedOnSiteMessage | $f_back.publish_component_loaded
                         with ComponentLoadedOnSiteMessage { id: Some("id".into()), reloaded: false, site_id: "site_id".into() }; );

--- a/hermes/src/lib.rs
+++ b/hermes/src/lib.rs
@@ -69,8 +69,8 @@ pub trait ComponentFacade: Send + Sync {
 pub trait IdentifiableComponentFacade: Send + Sync {
     fn publish_version_request(&self, id: String) -> Fallible<()>;
     fn subscribe_version(&self, id: String, handler: Callback<VersionMessage>) -> Fallible<()>;
-    fn subscribe_error(&self, id: String, handler: Callback<ErrorMessage>) -> Fallible<()>;
-    fn subscribe_all_error(&self, handler: Callback<ErrorMessage>) -> Fallible<()>;
+    fn subscribe_error(&self, id: String, handler: Callback<SiteErrorMessage>) -> Fallible<()>;
+    fn subscribe_all_error(&self, handler: Callback<SiteErrorMessage>) -> Fallible<()>;
     fn subscribe_component_loaded(&self, id: String, handler: Callback<ComponentLoadedOnSiteMessage>) -> Fallible<()>;
     fn subscribe_all_component_loaded(&self, handler: Callback<ComponentLoadedOnSiteMessage>) -> Fallible<()>;
 }
@@ -87,7 +87,7 @@ pub trait ComponentBackendFacade: Send + Sync {
 pub trait IdentifiableComponentBackendFacade: Send + Sync {
     fn subscribe_version_request(&self, id: String, handler: Callback0) -> Fallible<()>;
     fn publish_version(&self, id: String, version: VersionMessage) -> Fallible<()>;
-    fn publish_error(&self, id: String, error: ErrorMessage) -> Fallible<()>;
+    fn publish_error(&self, id: String, error: SiteErrorMessage) -> Fallible<()>;
     fn publish_component_loaded(&self, id: String, component_loaded: ComponentLoadedOnSiteMessage) -> Fallible<()>;
 }
 

--- a/hermes/src/lib.rs
+++ b/hermes/src/lib.rs
@@ -70,6 +70,7 @@ pub trait IdentifiableComponentFacade: Send + Sync {
     fn publish_version_request(&self, id: String) -> Fallible<()>;
     fn subscribe_version(&self, id: String, handler: Callback<VersionMessage>) -> Fallible<()>;
     fn subscribe_error(&self, id: String, handler: Callback<ErrorMessage>) -> Fallible<()>;
+    fn subscribe_all_error(&self, handler: Callback<ErrorMessage>) -> Fallible<()>;
     fn subscribe_component_loaded(&self, id: String, handler: Callback<ComponentLoadedOnSiteMessage>) -> Fallible<()>;
     fn subscribe_all_component_loaded(&self, handler: Callback<ComponentLoadedOnSiteMessage>) -> Fallible<()>;
 }

--- a/hermes/src/ontology/mod.rs
+++ b/hermes/src/ontology/mod.rs
@@ -67,6 +67,21 @@ impl<'de> HermesMessage<'de> for ErrorMessage {}
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SiteErrorMessage {
+    /// Site on which the error happened.
+    pub site_id: String,
+    /// An optional session id if there is a related session
+    pub session_id: Option<String>,
+    /// The error that occurred
+    pub error: String,
+    /// Optional additional information on the context in which the error occurred
+    pub context: Option<String>,
+}
+
+impl<'de> HermesMessage<'de> for SiteErrorMessage {}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum HermesComponent {
     AudioServer,
     Hotword,


### PR DESCRIPTION
At the moment, **identifiable** components do not resurface the error they may have to `snips-watch` ... 

To solve this, this P.R introduces a new object to the ontology ➡️➡️➡️ 
```
SiteErrorMessage
```

Now facades that impl the IdentifiableComponent trait all to publish and subscribe to such messages. 

This will be particularly useful for `snips-watch` so that the error can be printed back to the user, with the additional information on which site the error happened. 