### PR TITLE
Intents and slots alternatives

### DIFF
--- a/hermes-ffi/Cargo.toml
+++ b/hermes-ffi/Cargo.toml
@@ -18,9 +18,9 @@ hermes = { path = "../hermes" }
 lazy_static = { version="1.0" }
 libc = "0.2"
 serde_json = { version = "1.0", optional = true }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.65.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
 env_logger = "0.6"
 
 [dev-dependencies]
 spectral = "0.6"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.65.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }

--- a/hermes-ffi/src/ontology/dialogue.rs
+++ b/hermes-ffi/src/ontology/dialogue.rs
@@ -1163,6 +1163,10 @@ mod tests {
                 entity: "entity".to_string(),
                 slot_name: "forecast_location".to_string(),
                 confidence_score: Some(0.8),
+                alternatives: vec![
+                    snips_nlu_ontology::SlotValue::Custom("Gwadloup".to_string().into()),
+                    snips_nlu_ontology::SlotValue::Custom("Point a Pitre".to_string().into()),
+                ],
             },
         };
 
@@ -1206,6 +1210,10 @@ mod tests {
                             entity: "entity2".to_string(),
                             slot_name: "my_slot_name".to_string(),
                             confidence_score: Some(0.6),
+                            alternatives: vec![
+                                snips_nlu_ontology::SlotValue::Custom("Matnik".to_string().into()),
+                                snips_nlu_ontology::SlotValue::Custom("Fort de france".to_string().into()),
+                            ],
                         },
                     },
                     hermes::NluSlot {
@@ -1216,6 +1224,7 @@ mod tests {
                             entity: "entity3".to_string(),
                             slot_name: "another_slot_name".to_string(),
                             confidence_score: Some(0.7),
+                            alternatives: vec![],
                         },
                     },
                 ],
@@ -1232,6 +1241,10 @@ mod tests {
                             entity: "entity2".to_string(),
                             slot_name: "my_slot_name".to_string(),
                             confidence_score: Some(0.6),
+                            alternatives: vec![
+                                snips_nlu_ontology::SlotValue::Custom("Matnik".to_string().into()),
+                                snips_nlu_ontology::SlotValue::Custom("Fort de france".to_string().into()),
+                            ],
                         },
                     },
                     hermes::NluSlot {
@@ -1242,6 +1255,10 @@ mod tests {
                             entity: "entity3".to_string(),
                             slot_name: "another_slot_name".to_string(),
                             confidence_score: Some(0.7),
+                            alternatives: vec![
+                                snips_nlu_ontology::SlotValue::Custom("Matnik".to_string().into()),
+                                snips_nlu_ontology::SlotValue::Custom("Fort de france".to_string().into()),
+                            ],
                         },
                     },
                 ],

--- a/hermes-inprocess/Cargo.toml
+++ b/hermes-inprocess/Cargo.toml
@@ -13,4 +13,4 @@ log = "0.4"
 
 [dev-dependencies]
 semver = "0.9"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.65.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }

--- a/hermes-mqtt-ffi/Cargo.toml
+++ b/hermes-mqtt-ffi/Cargo.toml
@@ -21,6 +21,6 @@ hermes-ffi = { path = "../hermes-ffi" }
 hermes-mqtt = { path = "../hermes-mqtt" }
 libc = "0.2"
 log = "0.4"
-snips-nlu-ontology-ffi = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.65.0" }
+snips-nlu-ontology-ffi = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
 # Needed to fix cbindgen issue. See https://github.com/eqrion/cbindgen/issues/221
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.65.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }

--- a/hermes-mqtt/Cargo.toml
+++ b/hermes-mqtt/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "0.7", features = ["v4"] }
 [dev-dependencies]
 rand = "0.6"
 semver = "0.9"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.65.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
 
 [package.metadata.dinghy]
 ignored_rustc_triples = [

--- a/hermes-test-suite/src/lib.rs
+++ b/hermes-test-suite/src/lib.rs
@@ -394,7 +394,7 @@ macro_rules! test_suite {
             );
         t!(nlu_slot_parsed_works:
                     nlu.subscribe_slot_parsed <= NluSlotMessage | nlu_backend.publish_slot_parsed
-                    with NluSlotMessage { id: None, input: "some input".into(), intent_name: "some intent".into(), slot: Some(NluSlot { nlu_slot: Slot { slot_name: "my slot".into(), raw_value: "value".into(), value: snips_nlu_ontology::SlotValue::Custom("my slot".into()), range: 0..6, entity: "entity".into(), confidence_score: Some(1.) }}), session_id: Some("abc".into()) };
+                    with NluSlotMessage { id: None, input: "some input".into(), intent_name: "some intent".into(), slot: Some(NluSlot { nlu_slot: Slot { slot_name: "my slot".into(), raw_value: "value".into(), value: snips_nlu_ontology::SlotValue::Custom("my slot".into()), range: 0..6, entity: "entity".into(), confidence_score: Some(1.), alternatives: vec![snips_nlu_ontology::SlotValue::Custom("my slot 2".into())] }}), session_id: Some("abc".into()) };
             );
         t!(nlu_intent_parsed_works:
                     nlu.subscribe_intent_parsed <= NluIntentMessage | nlu_backend.publish_intent_parsed

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 base64 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.65.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
 semver = { version = "0.9", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"

--- a/platforms/hermes-kotlin/build.gradle
+++ b/platforms/hermes-kotlin/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile "ai.snips:snips-nlu-ontology:0.65.0"
+    compile "ai.snips:snips-nlu-ontology:0.67.0"
     compile 'net.java.dev.jna:jna:4.5.0'
     compile 'org.parceler:parceler-api:1.1.9'
 }


### PR DESCRIPTION
This PR bumps the version of `snips-nlu-ontology` to `0.67.0`. 
This new version of the ontology adds an `alternatives` attribute to both `IntentParserResult` and `Slot`. Besides it also introduces `IntentParserAlternative`:

```rust
#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
pub struct IntentParserResult {
    pub input: String,
    pub intent: IntentClassifierResult,
    pub slots: Vec<Slot>,
    pub alternatives: Vec<IntentParserAlternative>,
}

#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
pub struct IntentParserAlternative {
    pub intent: IntentClassifierResult,
    pub slots: Vec<Slot>,
}

#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
#[serde(rename_all = "camelCase")]
pub struct Slot {
    pub raw_value: String,
    pub value: SlotValue,
    pub alternatives: Vec<SlotValue>,
    pub range: Range<usize>,
    pub entity: String,
    pub slot_name: String,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub confidence_score: Option<f32>,
}
```

I guess the wrappers (kotlin, python, JS) must be updated accordingly cc @fredszaq @elbywan @anthonyray 