### PR TITLE
Example message derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,6 @@ members = [
     "hermes-mqtt",
     "hermes-mqtt-ffi",
     "hermes-test-suite",
+    "hermes-utils",
+    "hermes-utils-derive",
 ]

--- a/hermes-ffi/src/ontology/asr.rs
+++ b/hermes-ffi/src/ontology/asr.rs
@@ -384,16 +384,12 @@ impl Drop for CSpeakerIdArray {
 mod tests {
     use super::super::tests::round_trip_test;
     use super::*;
+    use hermes::hermes_utils::Example;
 
     #[test]
     fn round_trip_asr_token() {
-        round_trip_test::<_, CAsrToken>(hermes::AsrToken {
-            value: "hello world".into(),
-            confidence: 0.98,
-            range_start: 4,
-            range_end: 9,
-            time: hermes::AsrDecodingDuration { start: 0.0, end: 5.0 },
-        });
+        round_trip_test::<_, CAsrToken>(hermes::AsrToken::minimal_example());
+        round_trip_test::<_, CAsrToken>(hermes::AsrToken::full_example());
     }
 
     #[test]
@@ -401,20 +397,8 @@ mod tests {
         round_trip_test::<_, CAsrTokenArray>(vec![]);
 
         round_trip_test::<_, CAsrTokenArray>(vec![
-            hermes::AsrToken {
-                value: "hello".to_string(),
-                confidence: 0.98,
-                range_start: 1,
-                range_end: 4,
-                time: hermes::AsrDecodingDuration { start: 0.0, end: 5.0 },
-            },
-            hermes::AsrToken {
-                value: "world".to_string(),
-                confidence: 0.73,
-                range_start: 5,
-                range_end: 9,
-                time: hermes::AsrDecodingDuration { start: 0.0, end: 5.0 },
-            },
+            hermes::AsrToken::minimal_example(),
+            hermes::AsrToken::minimal_example(),
         ]);
     }
 
@@ -423,30 +407,9 @@ mod tests {
         round_trip_test::<_, CAsrTokenDoubleArray>(vec![]);
 
         round_trip_test::<_, CAsrTokenDoubleArray>(vec![
-            vec![
-                hermes::AsrToken {
-                    value: "hello".to_string(),
-                    confidence: 0.98,
-                    range_start: 1,
-                    range_end: 4,
-                    time: hermes::AsrDecodingDuration { start: 0.0, end: 5.0 },
-                },
-                hermes::AsrToken {
-                    value: "world".to_string(),
-                    confidence: 0.73,
-                    range_start: 5,
-                    range_end: 9,
-                    time: hermes::AsrDecodingDuration { start: 0.0, end: 5.0 },
-                },
-            ],
+            vec![hermes::AsrToken::minimal_example(), hermes::AsrToken::full_example()],
             vec![],
-            vec![hermes::AsrToken {
-                value: "yop".to_string(),
-                confidence: 0.97,
-                range_start: 5,
-                range_end: 1,
-                time: hermes::AsrDecodingDuration { start: 1.0, end: 4.5 },
-            }],
+            vec![hermes::AsrToken::full_example()],
         ]);
     }
 }

--- a/hermes-ffi/src/ontology/dialogue.rs
+++ b/hermes-ffi/src/ontology/dialogue.rs
@@ -982,109 +982,68 @@ impl Drop for CDialogueConfigureMessage {
 mod tests {
     use std::ops::Range;
 
+    use hermes::hermes_utils::Example;
+
     use super::super::tests::round_trip_test;
     use super::*;
 
     #[test]
     fn round_trip_intent_not_recognized() {
-        round_trip_test::<_, CIntentNotRecognizedMessage>(hermes::IntentNotRecognizedMessage {
-            site_id: "siteid".into(),
-            custom_data: Some("custom".into()),
-            session_id: "session id".into(),
-            speaker_hypotheses: None,
-            input: Some("some text".into()),
-            confidence_score: 0.5,
-            alternatives: Some(vec![hermes::NluIntentAlternative {
-                slots: vec![],
-                confidence_score: 0.8,
-                intent_name: Some("some intent name".into()),
-            }]),
-        });
+        round_trip_test::<_, CIntentNotRecognizedMessage>(hermes::IntentNotRecognizedMessage::minimal_example());
 
         round_trip_test::<_, CIntentNotRecognizedMessage>(hermes::IntentNotRecognizedMessage {
-            site_id: "siteid".into(),
-            custom_data: None,
-            session_id: "session id".into(),
-            speaker_hypotheses: None,
-            input: None,
-            confidence_score: 0.5,
-            alternatives: None,
+            speaker_hypotheses: None, // TODO these are not supported by the ffi just yet
+            ..hermes::IntentNotRecognizedMessage::full_example()
         });
     }
 
     #[test]
     fn round_trip_session_started() {
-        round_trip_test::<_, CSessionStartedMessage>(hermes::SessionStartedMessage {
-            site_id: "siteid".into(),
-            custom_data: Some("custom".into()),
-            session_id: "session id".into(),
-            reactivated_from_session_id: Some("other session id".into()),
-        });
+        round_trip_test::<_, CSessionStartedMessage>(hermes::SessionStartedMessage::minimal_example());
 
-        round_trip_test::<_, CSessionStartedMessage>(hermes::SessionStartedMessage {
-            site_id: "siteid".into(),
-            custom_data: None,
-            session_id: "session id".into(),
-            reactivated_from_session_id: None,
-        })
+        round_trip_test::<_, CSessionStartedMessage>(hermes::SessionStartedMessage::full_example())
     }
 
     #[test]
     fn round_trip_session_ended() {
-        round_trip_test::<_, CSessionEndedMessage>(hermes::SessionEndedMessage {
-            site_id: "siteid".into(),
-            custom_data: Some("custom".into()),
-            session_id: "session id".into(),
-            termination: hermes::SessionTerminationType::Nominal,
-        });
+        round_trip_test::<_, CSessionEndedMessage>(hermes::SessionEndedMessage::minimal_example());
+        round_trip_test::<_, CSessionEndedMessage>(hermes::SessionEndedMessage::full_example());
 
         round_trip_test::<_, CSessionEndedMessage>(hermes::SessionEndedMessage {
-            site_id: "siteid".into(),
-            custom_data: None,
-            session_id: "session_id".into(),
             termination: hermes::SessionTerminationType::Error {
                 error: "this is my error".into(),
             },
+            ..hermes::SessionEndedMessage::full_example()
         });
 
         round_trip_test::<_, CSessionEndedMessage>(hermes::SessionEndedMessage {
-            site_id: "siteid".into(),
-            custom_data: None,
-            session_id: "session_id".into(),
             termination: hermes::SessionTerminationType::Timeout { component: None },
+            ..hermes::SessionEndedMessage::full_example()
         });
 
         round_trip_test::<_, CSessionEndedMessage>(hermes::SessionEndedMessage {
-            site_id: "siteid".into(),
-            custom_data: None,
-            session_id: "session_id".into(),
             termination: hermes::SessionTerminationType::Timeout {
                 component: Some(hermes::HermesComponent::Hotword),
             },
+            ..hermes::SessionEndedMessage::full_example()
         })
     }
 
     #[test]
     fn round_trip_session_queued() {
-        round_trip_test::<_, CSessionQueuedMessage>(hermes::SessionQueuedMessage {
-            site_id: "siteid".into(),
-            custom_data: Some("custom".into()),
-            session_id: "session id".into(),
-        });
+        round_trip_test::<_, CSessionQueuedMessage>(hermes::SessionQueuedMessage::minimal_example());
 
-        round_trip_test::<_, CSessionQueuedMessage>(hermes::SessionQueuedMessage {
-            site_id: "siteid".into(),
-            custom_data: None,
-            session_id: "session_id".into(),
-        })
+        round_trip_test::<_, CSessionQueuedMessage>(hermes::SessionQueuedMessage::full_example())
     }
 
     #[test]
     fn round_trip_start_session() {
+        round_trip_test::<_, CStartSessionMessage>(hermes::StartSessionMessage::minimal_example());
+        round_trip_test::<_, CStartSessionMessage>(hermes::StartSessionMessage::full_example());
+
         round_trip_test::<_, CStartSessionMessage>(hermes::StartSessionMessage {
             init: hermes::SessionInit::Notification { text: "text".into() },
-            custom_data: Some("thing".into()),
-            site_id: Some("site".into()),
+            ..hermes::StartSessionMessage::full_example()
         });
 
         round_trip_test::<_, CStartSessionMessage>(hermes::StartSessionMessage {
@@ -1094,8 +1053,7 @@ mod tests {
                 can_be_enqueued: true,
                 send_intent_not_recognized: false,
             },
-            custom_data: Some("thing".into()),
-            site_id: Some("site".into()),
+            ..hermes::StartSessionMessage::full_example()
         });
 
         round_trip_test::<_, CStartSessionMessage>(hermes::StartSessionMessage {
@@ -1105,67 +1063,39 @@ mod tests {
                 can_be_enqueued: false,
                 send_intent_not_recognized: true,
             },
-            custom_data: None,
-            site_id: None,
+            ..hermes::StartSessionMessage::minimal_example()
         });
     }
 
     #[test]
     fn round_trip_continue_session() {
-        round_trip_test::<_, CContinueSessionMessage>(hermes::ContinueSessionMessage {
-            session_id: "my session id".into(),
-            text: "some text".into(),
-            intent_filter: Some(vec!["filter1".into(), "filter2".into()]),
-            custom_data: Some("foo bar".into()),
-            slot: Some("some slot".into()),
-            send_intent_not_recognized: true,
-        });
+        round_trip_test::<_, CContinueSessionMessage>(hermes::ContinueSessionMessage::minimal_example());
+
+        round_trip_test::<_, CContinueSessionMessage>(hermes::ContinueSessionMessage::full_example());
 
         round_trip_test::<_, CContinueSessionMessage>(hermes::ContinueSessionMessage {
-            session_id: "my session id".into(),
-            text: "some text".into(),
-            intent_filter: None,
-            custom_data: None,
-            slot: None,
-            send_intent_not_recognized: false,
-        });
-
-        round_trip_test::<_, CContinueSessionMessage>(hermes::ContinueSessionMessage {
-            session_id: "my session id".into(),
-            text: "some text".into(),
             intent_filter: Some(vec![]),
             custom_data: Some("".into()),
             slot: Some("".into()),
             send_intent_not_recognized: true,
+            ..hermes::ContinueSessionMessage::full_example()
         });
     }
 
     #[test]
     fn round_trip_end_session() {
-        round_trip_test::<_, CEndSessionMessage>(hermes::EndSessionMessage {
-            session_id: "my session id".into(),
-            text: Some("some text".into()),
-        });
+        round_trip_test::<_, CEndSessionMessage>(hermes::EndSessionMessage::minimal_example());
 
-        round_trip_test::<_, CEndSessionMessage>(hermes::EndSessionMessage {
-            session_id: "my session id".into(),
-            text: None,
-        });
+        round_trip_test::<_, CEndSessionMessage>(hermes::EndSessionMessage::full_example());
     }
 
     #[test]
     fn round_trip_dialogue_configure_intent() {
+        round_trip_test::<_, CDialogueConfigureIntent>(hermes::DialogueConfigureIntent::minimal_example());
+        round_trip_test::<_, CDialogueConfigureIntent>(hermes::DialogueConfigureIntent::full_example());
         round_trip_test::<_, CDialogueConfigureIntent>(hermes::DialogueConfigureIntent {
-            intent_id: "my intent".into(),
             enable: Some(true),
-        });
-        round_trip_test::<_, CDialogueConfigureIntent>(hermes::DialogueConfigureIntent {
-            intent_id: "an intent".into(),
-            enable: Some(false),
-        });
-        round_trip_test::<_, CDialogueConfigureIntent>(hermes::DialogueConfigureIntent {
-            intent_id: "".into(),
-            enable: None,
+            ..hermes::DialogueConfigureIntent::full_example()
         });
     }
 
@@ -1173,17 +1103,11 @@ mod tests {
     fn round_trip_dialogue_configure_intent_array() {
         round_trip_test::<_, CDialogueConfigureIntentArray>(vec![
             hermes::DialogueConfigureIntent {
-                intent_id: "my intent".into(),
                 enable: Some(true),
+                ..hermes::DialogueConfigureIntent::full_example()
             },
-            hermes::DialogueConfigureIntent {
-                intent_id: "an intent".into(),
-                enable: Some(false),
-            },
-            hermes::DialogueConfigureIntent {
-                intent_id: "".into(),
-                enable: None,
-            },
+            hermes::DialogueConfigureIntent::full_example(),
+            hermes::DialogueConfigureIntent::minimal_example(),
         ]);
 
         round_trip_test::<_, CDialogueConfigureIntentArray>(vec![]);
@@ -1191,28 +1115,9 @@ mod tests {
 
     #[test]
     fn round_trip_dialogue_configure() {
-        round_trip_test::<_, CDialogueConfigureMessage>(hermes::DialogueConfigureMessage {
-            site_id: Some("some site".into()),
-            intents: Some(vec![
-                hermes::DialogueConfigureIntent {
-                    intent_id: "my intent".into(),
-                    enable: Some(true),
-                },
-                hermes::DialogueConfigureIntent {
-                    intent_id: "an intent".into(),
-                    enable: Some(false),
-                },
-                hermes::DialogueConfigureIntent {
-                    intent_id: "".into(),
-                    enable: None,
-                },
-            ]),
-        });
+        round_trip_test::<_, CDialogueConfigureMessage>(hermes::DialogueConfigureMessage::minimal_example());
 
-        round_trip_test::<_, CDialogueConfigureMessage>(hermes::DialogueConfigureMessage {
-            site_id: None,
-            intents: None,
-        });
+        round_trip_test::<_, CDialogueConfigureMessage>(hermes::DialogueConfigureMessage::full_example());
     }
 
     #[test]

--- a/hermes-ffi/src/ontology/injection.rs
+++ b/hermes-ffi/src/ontology/injection.rs
@@ -390,7 +390,7 @@ impl AsRust<hermes::InjectionResetCompleteMessage> for CInjectionResetCompleteMe
 mod tests {
     use super::super::tests::round_trip_test;
     use super::*;
-    use chrono::prelude::*;
+    use hermes::hermes_utils::Example;
 
     #[test]
     fn round_trip_injection_request_operation() {
@@ -461,7 +461,7 @@ mod tests {
 
         round_trip_test::<_, CInjectionRequestOperations>(vec![
             (hermes::InjectionKind::Add, HashMap::new()),
-            (hermes::InjectionKind::Add, test_map),
+            (hermes::InjectionKind::AddFromVanilla, test_map),
         ]);
     }
 
@@ -515,30 +515,26 @@ mod tests {
 
     #[test]
     fn round_trip_injection_status() {
-        round_trip_test::<_, CInjectionStatusMessage>(hermes::InjectionStatusMessage {
-            last_injection_date: Some(Utc.ymd(2014, 11, 28).and_hms(12, 0, 9)),
-        });
+        round_trip_test::<_, CInjectionStatusMessage>(hermes::InjectionStatusMessage::minimal_example());
+        round_trip_test::<_, CInjectionStatusMessage>(hermes::InjectionStatusMessage::full_example());
     }
 
     #[test]
     fn round_trip_injection_complete() {
-        round_trip_test::<_, CInjectionCompleteMessage>(hermes::InjectionCompleteMessage {
-            request_id: Some("identifier".to_string()),
-        });
+        round_trip_test::<_, CInjectionCompleteMessage>(hermes::InjectionCompleteMessage::minimal_example());
+        round_trip_test::<_, CInjectionCompleteMessage>(hermes::InjectionCompleteMessage::full_example());
     }
 
     #[test]
     fn round_trip_injection_reset_request() {
-        round_trip_test::<_, CInjectionResetRequestMessage>(hermes::InjectionResetRequestMessage {
-            request_id: Some("some id".to_string()),
-        })
+        round_trip_test::<_, CInjectionResetRequestMessage>(hermes::InjectionResetRequestMessage::minimal_example());
+        round_trip_test::<_, CInjectionResetRequestMessage>(hermes::InjectionResetRequestMessage::full_example());
     }
 
     #[test]
     fn round_trip_injection_reset_complete() {
-        round_trip_test::<_, CInjectionResetCompleteMessage>(hermes::InjectionResetCompleteMessage {
-            request_id: Some("some id".to_string()),
-        })
+        round_trip_test::<_, CInjectionResetCompleteMessage>(hermes::InjectionResetCompleteMessage::minimal_example());
+        round_trip_test::<_, CInjectionResetCompleteMessage>(hermes::InjectionResetCompleteMessage::full_example());
     }
 
 }

--- a/hermes-ffi/src/ontology/nlu.rs
+++ b/hermes-ffi/src/ontology/nlu.rs
@@ -561,17 +561,11 @@ impl Drop for CNluIntentClassifierResult {
 mod tests {
     use super::super::tests::round_trip_test;
     use super::*;
+    use hermes::hermes_utils::Example;
 
     #[test]
     fn round_trip_intent_classifier_result() {
-        round_trip_test::<_, CNluIntentClassifierResult>(hermes::NluIntentClassifierResult {
-            intent_name: "MakeCoffee".into(),
-            confidence_score: 0.5,
-        });
-
-        round_trip_test::<_, CNluIntentClassifierResult>(hermes::NluIntentClassifierResult {
-            intent_name: "MakeCoffee".into(),
-            confidence_score: 0.5,
-        });
+        round_trip_test::<_, CNluIntentClassifierResult>(hermes::NluIntentClassifierResult::minimal_example());
+        round_trip_test::<_, CNluIntentClassifierResult>(hermes::NluIntentClassifierResult::full_example());
     }
 }

--- a/hermes-ffi/src/ontology/tts.rs
+++ b/hermes-ffi/src/ontology/tts.rs
@@ -157,12 +157,11 @@ impl Drop for CRegisterSoundMessage {
 mod tests {
     use super::super::tests::round_trip_test;
     use super::*;
+    use hermes::hermes_utils::Example;
 
     #[test]
     fn round_trip_register_sound() {
-        round_trip_test::<_, CRegisterSoundMessage>(hermes::RegisterSoundMessage {
-            sound_id: "my sound id".into(),
-            wav_sound: vec![6; 513],
-        });
+        round_trip_test::<_, CRegisterSoundMessage>(hermes::RegisterSoundMessage::minimal_example());
+        round_trip_test::<_, CRegisterSoundMessage>(hermes::RegisterSoundMessage::full_example());
     }
 }

--- a/hermes-test-suite/src/lib.rs
+++ b/hermes-test-suite/src/lib.rs
@@ -12,8 +12,7 @@ macro_rules! t {
         $s:ident <=
         $t:ty |
         $p_facade:ident.
-        $p:ident with
-        $object:expr;
+        $p:ident
     ) => {
         #[test]
         fn $name() {
@@ -27,7 +26,8 @@ macro_rules! t {
                     tx.lock().map(|it| it.send(o.clone())).unwrap().unwrap()
                 }))
                 .unwrap();
-            let message = $object;
+            use hermes::hermes_utils::Example;
+            let message = <$t>::full_example();
             std::thread::sleep(WAIT_DURATION);
             source.$p(message.clone()).unwrap();
             let result = rx.recv_timeout(std::time::Duration::from_secs(1));
@@ -81,8 +81,7 @@ macro_rules! t {
         $a:block <=
         $t:ty |
         $p_facade:ident.
-        $p:ident with
-        $object:expr;
+        $p:ident
     ) => {
         #[test]
         fn $name() {
@@ -97,7 +96,8 @@ macro_rules! t {
                     hermes::Callback::new(move |o: &$t| tx.lock().map(|it| it.send(o.clone())).unwrap().unwrap()),
                 )
                 .unwrap();
-            let message = $object;
+            use hermes::hermes_utils::Example;
+            let message = <$t>::full_example();
             std::thread::sleep(WAIT_DURATION);
             source.$p($a, message.clone()).unwrap();
             let result = rx.recv_timeout(std::time::Duration::from_secs(1));
@@ -129,11 +129,10 @@ macro_rules! t {
         $name:ident : OneToMany
         $s_facade:ident.
         $s:ident
-        $a:block <=
+        ($($field:ident).+) <=
         $t:ty |
         $p_facade:ident.
-        $p:ident with
-        $object:expr;
+        $p:ident
     ) => {
         #[test]
         fn $name() {
@@ -142,13 +141,15 @@ macro_rules! t {
             let receiver = handler_receiver.$s_facade();
             let (tx, rx) = std::sync::mpsc::channel();
             let tx = std::sync::Mutex::new(tx);
+            let message = <$t>::full_example();
             receiver
                 .$s(
-                    $a,
+                    message.$($field).*.clone(),
                     hermes::Callback::new(move |o: &$t| tx.lock().map(|it| it.send(o.clone())).unwrap().unwrap()),
                 )
                 .unwrap();
-            let message = $object;
+            use hermes::hermes_utils::Example;
+
             std::thread::sleep(WAIT_DURATION);
             source.$p(message.clone()).unwrap();
             let result = rx.recv_timeout(std::time::Duration::from_secs(1));
@@ -182,8 +183,7 @@ macro_rules! t {
         $t:ty |
         $p_facade:ident.
         $p:ident
-        $a:block with
-        $object:expr;
+        $a:block
     ) => {
         #[test]
         fn $name() {
@@ -197,7 +197,8 @@ macro_rules! t {
                     tx.lock().map(|it| it.send(o.clone())).unwrap().unwrap()
                 }))
                 .unwrap();
-            let message = $object;
+            use hermes::hermes_utils::Example;
+            let message = <$t>::full_example();
             std::thread::sleep(WAIT_DURATION);
             source.$p($a, message.clone()).unwrap();
             let result = rx.recv_timeout(std::time::Duration::from_secs(1));
@@ -212,8 +213,6 @@ macro_rules! t {
         $t:ty |
         $p_facade:ident.
         $p:ident
-        with
-        $object:expr;
     ) => {
         #[test]
         fn $name() {
@@ -227,7 +226,8 @@ macro_rules! t {
                     tx.lock().map(|it| it.send(o.clone())).unwrap().unwrap()
                 }))
                 .unwrap();
-            let message = $object;
+            use hermes::hermes_utils::Example;
+            let message = <$t>::full_example();
             std::thread::sleep(WAIT_DURATION);
             source.$p(message.clone()).unwrap();
             let result = rx.recv_timeout(std::time::Duration::from_secs(1));
@@ -256,11 +256,9 @@ macro_rules! t_identifiable_toggleable {
             mod $name {
                 use super::*;
                 t!(toggle_on_works:
-                        $f_back.subscribe_toggle_on <= SiteMessage | $f.publish_toggle_on
-                        with SiteMessage { session_id: Some("abc".into()), site_id: "some site".into() };);
+                        $f_back.subscribe_toggle_on <= SiteMessage | $f.publish_toggle_on);
                 t!(toggle_off_works:
-                        $f_back.subscribe_toggle_off <= SiteMessage | $f.publish_toggle_off
-                        with SiteMessage { session_id: Some("abc".into()), site_id: "some site".into() };);
+                        $f_back.subscribe_toggle_off <= SiteMessage | $f.publish_toggle_off);
             }
         };
     }
@@ -273,14 +271,11 @@ macro_rules! t_component {
                 t!(version_request_works:
                         $f_back.subscribe_version_request <= $f.publish_version_request);
                 t!(version_works:
-                        $f.subscribe_version <= VersionMessage | $f_back.publish_version
-                        with VersionMessage { version: semver::Version { major: 1, minor: 0, patch: 0, pre: vec![], build: vec![]} };);
+                        $f.subscribe_version <= VersionMessage | $f_back.publish_version);
                 t!(error_works:
-                        $f.subscribe_error <= ErrorMessage | $f_back.publish_error
-                        with ErrorMessage { session_id: Some("123abc".into()), error: "some error".into(), context: None };);
+                        $f.subscribe_error <= ErrorMessage | $f_back.publish_error);
                 t!(component_loaded_works:
-                        $f.subscribe_component_loaded <= ComponentLoadedMessage | $f_back.publish_component_loaded
-                        with ComponentLoadedMessage { id: Some("123abc".into()), reloaded: false };);
+                        $f.subscribe_component_loaded <= ComponentLoadedMessage | $f_back.publish_component_loaded);
             }
         };
     }
@@ -293,22 +288,17 @@ macro_rules! t_identifiable_component {
                 t!(version_request_works:
                         $f_back.subscribe_version_request { "identifier".to_string() } <= $f.publish_version_request);
                 t!(version_works:
-                        $f.subscribe_version { "identifier".to_string() } <= VersionMessage | $f_back.publish_version
-                        with VersionMessage { version: semver::Version { major: 1, minor: 0, patch: 0, pre: vec![], build: vec![]} };);
+                        $f.subscribe_version { "identifier".to_string() } <= VersionMessage | $f_back.publish_version);
                 t!(error_works:
-                        $f.subscribe_error { "identifier".to_string() } <= SiteErrorMessage | $f_back.publish_error
-                        with SiteErrorMessage { session_id: Some("123abc".into()), error: "some error".into(), context: None, site_id: "identifier".into() };);
+                        $f.subscribe_error { "identifier".to_string() } <= SiteErrorMessage | $f_back.publish_error);
                 t!(all_error_works:
                         ManyToOne
-                        $f.subscribe_all_error <= SiteErrorMessage | $f_back.publish_error { "identifier".into() }
-                        with SiteErrorMessage { session_id: Some("123abc".into()), error: "some error".into(), context: None, site_id: "identifier".into() };);
+                        $f.subscribe_all_error <= SiteErrorMessage | $f_back.publish_error { "identifier".into() });
                 t!(component_loaded_works:
-                        $f.subscribe_component_loaded { "identifier".to_string() } <= ComponentLoadedOnSiteMessage | $f_back.publish_component_loaded
-                        with ComponentLoadedOnSiteMessage { id: Some("id".into()), reloaded: false, site_id: "site_id".into() }; );
+                        $f.subscribe_component_loaded { "identifier".to_string() } <= ComponentLoadedOnSiteMessage | $f_back.publish_component_loaded );
                 t!(components_loaded_works:
                         ManyToOne
-                        $f.subscribe_all_component_loaded <= ComponentLoadedOnSiteMessage | $f_back.publish_component_loaded { "site_id".into() }
-                        with ComponentLoadedOnSiteMessage { id: Some("id".into()), reloaded: false, site_id: "site_id".into() }; );
+                        $f.subscribe_all_component_loaded <= ComponentLoadedOnSiteMessage | $f_back.publish_component_loaded { "site_id".into() });
             }
         };
     }
@@ -328,175 +318,120 @@ macro_rules! test_suite {
         t_identifiable_component!(voice_activity_identifiable_component: voice_activity_backend | voice_activity);
         t!(voice_activity_vad_up_works:
                     OneToMany
-                    voice_activity.subscribe_vad_up { "site_id".into() } <= VadUpMessage | voice_activity_backend.publish_vad_up
-                    with VadUpMessage { site_id: "site_id".into(), signal_ms: Some(1664) };);
+                    voice_activity.subscribe_vad_up(site_id) <= VadUpMessage | voice_activity_backend.publish_vad_up);
         t!(voice_activity_vad_down_works:
                     OneToMany
-                    voice_activity.subscribe_vad_down { "site_id".into() } <= VadDownMessage | voice_activity_backend.publish_vad_down
-                    with VadDownMessage { site_id: "site_id".into(), signal_ms: Some(4242) };);
+                    voice_activity.subscribe_vad_down(site_id) <= VadDownMessage | voice_activity_backend.publish_vad_down);
         t!(voice_activity_all_vad_up_works:
                     ManyToOne
-                    voice_activity.subscribe_all_vad_up <= VadUpMessage | voice_activity_backend.publish_vad_up
-                    with VadUpMessage { site_id: "site_id".into(), signal_ms: Some(1664) };);
+                    voice_activity.subscribe_all_vad_up <= VadUpMessage | voice_activity_backend.publish_vad_up);
         t!(voice_activity_all_vad_down_works:
                     ManyToOne
-                    voice_activity.subscribe_all_vad_down <= VadDownMessage | voice_activity_backend.publish_vad_down
-                    with VadDownMessage { site_id: "site_id".into(), signal_ms: Some(1664) };);
+                    voice_activity.subscribe_all_vad_down <= VadDownMessage | voice_activity_backend.publish_vad_down);
 
         t_identifiable_component!(hotword_identifiable_component: hotword_backend | hotword);
         t_identifiable_toggleable!(hotword_identifiable_toggleable: hotword_backend | hotword);
         t!(hotword_detected_works:
-                    hotword.subscribe_detected { "hotword_identifier".into() } <= HotwordDetectedMessage | hotword_backend.publish_detected
-                    with HotwordDetectedMessage { model_id: "some model".into(), site_id: "some site".into(), model_type: Some(hermes::HotwordModelType::Universal), model_version: Some("1.2.3".into()), current_sensitivity: Some(0.5), detection_signal_ms: None, end_signal_ms: None };);
+                    hotword.subscribe_detected { "hotword_identifier".into() } <= HotwordDetectedMessage | hotword_backend.publish_detected);
         t!(hotword_all_detected_works:
                     ManyToOne
-                    hotword.subscribe_all_detected <= HotwordDetectedMessage | hotword_backend.publish_detected { "hotword_identifier".into() }
-                    with HotwordDetectedMessage { model_id: "some model".into(), site_id: "some site".into(), model_type: Some(hermes::HotwordModelType::Universal), model_version: Some("1.2.3".into()), current_sensitivity: Some(0.5), detection_signal_ms: Some(12345), end_signal_ms: None };);
+                    hotword.subscribe_all_detected <= HotwordDetectedMessage | hotword_backend.publish_detected { "hotword_identifier".into() });
 
         t_identifiable_toggleable!(sound_feedback_identifiable_toggleable: sound_feedback_backend | sound_feedback );
 
         t_component!(asr_component: asr_backend | asr);
         t_toggleable!(asr_toggleable: asr_backend | asr);
         t!(asr_text_captured_works:
-                    asr.subscribe_text_captured <= TextCapturedMessage | asr_backend.publish_text_captured
-                    with TextCapturedMessage { text: "hello world".into(), tokens: Some(vec![ AsrToken { value: "hello".into(), confidence: 1., range_start: 0, range_end: 4, time: AsrDecodingDuration { start: 0.0, end: 2.0 } }, ]), likelihood: 0.5, seconds: 4.2, site_id: "Some site".into(), speaker_hypotheses: None, session_id: Some("123abc".into()) };);
+                    asr.subscribe_text_captured <= TextCapturedMessage | asr_backend.publish_text_captured);
         t!(asr_partial_text_captured_works:
-                    asr.subscribe_partial_text_captured <= TextCapturedMessage | asr_backend.publish_partial_text_captured
-                    with TextCapturedMessage { text: "hello world".into(), tokens: Some(vec![ AsrToken { value: "hello".into(), confidence: 1., range_start: 0, range_end: 4, time: AsrDecodingDuration { start: 0.0, end: 2.0 } }, AsrToken { value: "world".into(), confidence: 1., range_start: 5, range_end: 9, time: AsrDecodingDuration { start: 2.0, end: 4.0 } }, ]), likelihood: 0.5, seconds: 4.2, site_id: "Some site".into(), speaker_hypotheses: Some(vec![SpeakerId { name: Some("toto".into()), confidence: 0.9}]), session_id: Some("123abc".into()) };);
+                    asr.subscribe_partial_text_captured <= TextCapturedMessage | asr_backend.publish_partial_text_captured);
         t!(asr_start_listening:
-                    asr_backend.subscribe_start_listening <= AsrStartListeningMessage | asr.publish_start_listening
-                    with AsrStartListeningMessage { session_id: Some("abc".into()), site_id: "some site".into(), start_signal_ms: Some(12) };);
+                    asr_backend.subscribe_start_listening <= AsrStartListeningMessage | asr.publish_start_listening);
         t!(asr_stop_listening:
-                    asr_backend.subscribe_stop_listening <= SiteMessage | asr.publish_stop_listening
-                    with SiteMessage { session_id: Some("abc".into()), site_id: "some site".into() };);
+                    asr_backend.subscribe_stop_listening <= SiteMessage | asr.publish_stop_listening);
         t!(asr_reload:
-                    asr_backend.subscribe_component_reload <= RequestComponentReloadMessage | asr.publish_component_reload
-                    with RequestComponentReloadMessage { id: "abc".into() }; );
+                    asr_backend.subscribe_component_reload <= RequestComponentReloadMessage | asr.publish_component_reload );
 
         t_component!(tts_component: tts_backend | tts);
         t!(tts_say_works:
-                    tts_backend.subscribe_say <= SayMessage | tts.publish_say
-                    with SayMessage { text: "hello world".into(), lang: None, id: None, site_id: "some site".into(), session_id: Some("abc".into()) };
-            );
+                    tts_backend.subscribe_say <= SayMessage | tts.publish_say);
         t!(tts_say_finished_works:
-                    tts.subscribe_say_finished <= SayFinishedMessage | tts_backend.publish_say_finished
-                    with SayFinishedMessage { id: Some("my id".into()), session_id: Some("abc".into()) };
-            );
+                    tts.subscribe_say_finished <= SayFinishedMessage | tts_backend.publish_say_finished);
         t!(tts_register_sound_works:
-                    tts_backend.subscribe_register_sound <= RegisterSoundMessage | tts.publish_register_sound
-                    with RegisterSoundMessage { sound_id: "foobar".into(), wav_sound: vec![0; 10000] };
-            );
+                    tts_backend.subscribe_register_sound <= RegisterSoundMessage | tts.publish_register_sound);
 
         t_component!(nlu_component: nlu_backend | nlu);
         t!(nlu_query_works:
-                    nlu_backend.subscribe_query <= NluQueryMessage | nlu.publish_query
-                    with NluQueryMessage { input: "hello world".into(), asr_tokens: Some(vec![AsrToken { value: "hello".into(), confidence: 1., range_start: 0, range_end: 4, time: AsrDecodingDuration { start: 0.0, end: 2.0 }}]), intent_filter: None, id: None, session_id: Some("abc".into()) };
-            );
+                    nlu_backend.subscribe_query <= NluQueryMessage | nlu.publish_query);
         t!(nlu_partial_query_works:
-                    nlu_backend.subscribe_partial_query <= NluSlotQueryMessage | nlu.publish_partial_query
-                    with NluSlotQueryMessage { input: "hello world".into(), asr_tokens: Some(vec![AsrToken { value: "hello".into(), confidence: 1., range_start: 0, range_end: 4, time: AsrDecodingDuration { start: 0.0, end: 2.0 }}]), intent_name: "my intent".into(), slot_name: "my slot".into(), id: None, session_id: Some("abc".into()) };
-            );
+                    nlu_backend.subscribe_partial_query <= NluSlotQueryMessage | nlu.publish_partial_query);
         t!(nlu_slot_parsed_works:
-                    nlu.subscribe_slot_parsed <= NluSlotMessage | nlu_backend.publish_slot_parsed
-                    with NluSlotMessage { id: None, input: "some input".into(), intent_name: "some intent".into(), slot: Some(NluSlot { nlu_slot: Slot { slot_name: "my slot".into(), raw_value: "value".into(), value: snips_nlu_ontology::SlotValue::Custom("my slot".into()), range: 0..6, entity: "entity".into(), confidence_score: Some(1.), alternatives: vec![snips_nlu_ontology::SlotValue::Custom("my slot 2".into())] }}), session_id: Some("abc".into()) };
-            );
+                    nlu.subscribe_slot_parsed <= NluSlotMessage | nlu_backend.publish_slot_parsed);
         t!(nlu_intent_parsed_works:
-                    nlu.subscribe_intent_parsed <= NluIntentMessage | nlu_backend.publish_intent_parsed
-                    with NluIntentMessage { id: None, input: "hello world".into(), intent: NluIntentClassifierResult { intent_name: "my intent".into(), confidence_score: 0.73 }, slots: vec![], session_id: Some("abc".into()), alternatives: Some(vec![hermes::NluIntentAlternative {intent_name: Some("foobar".into()), confidence_score: 0.5, slots:vec![]}, hermes::NluIntentAlternative {intent_name: None, confidence_score: 0.4, slots:vec![]} ]) };);
+                    nlu.subscribe_intent_parsed <= NluIntentMessage | nlu_backend.publish_intent_parsed);
         t!(nlu_intent_not_recognized_works:
-                    nlu.subscribe_intent_not_recognized <= NluIntentNotRecognizedMessage | nlu_backend.publish_intent_not_recognized
-                    with NluIntentNotRecognizedMessage { id: None, input: "hello world".into(), session_id: Some("abc".into()), confidence_score: 0.5, alternatives: Some(vec![hermes::NluIntentAlternative {intent_name: Some("foobaz".into()), confidence_score: 0.5, slots:vec![]}, hermes::NluIntentAlternative {intent_name: None, confidence_score: 0.4, slots:vec![]} ]) };);
+                    nlu.subscribe_intent_not_recognized <= NluIntentNotRecognizedMessage | nlu_backend.publish_intent_not_recognized);
         t!(nlu_reload:
-                    nlu_backend.subscribe_component_reload <= RequestComponentReloadMessage | nlu.publish_component_reload
-                    with RequestComponentReloadMessage { id: "abc".into() }; );
+                    nlu_backend.subscribe_component_reload <= RequestComponentReloadMessage | nlu.publish_component_reload );
 
         t_identifiable_component!(audio_server_component: audio_server_backend | audio_server);
         t_identifiable_toggleable!(audio_server_toggeable: audio_server_backend | audio_server);
         t!(audio_server_play_bytes_works:
                     OneToMany
-                    audio_server_backend.subscribe_play_bytes { "some site".into() } <= PlayBytesMessage | audio_server.publish_play_bytes
-                    with PlayBytesMessage { wav_bytes: vec![42; 1000], id: "my id".into(), site_id: "some site".into() };
-            );
+                    audio_server_backend.subscribe_play_bytes(site_id) <= PlayBytesMessage | audio_server.publish_play_bytes);
         t!(audio_server_play_all_bytes_works:
-                    audio_server_backend.subscribe_all_play_bytes <= PlayBytesMessage | audio_server.publish_play_bytes
-                    with PlayBytesMessage { wav_bytes: vec![42; 1000], id: "my id".into(), site_id: "some site".into() };
-            );
+                    audio_server_backend.subscribe_all_play_bytes <= PlayBytesMessage | audio_server.publish_play_bytes);
         t!(audio_server_play_finished_works:
                     OneToMany
-                    audio_server.subscribe_play_finished { "some site".into() } <= PlayFinishedMessage | audio_server_backend.publish_play_finished
-                    with PlayFinishedMessage { id: "my id".into(), site_id: "some site".into() };
-            );
+                    audio_server.subscribe_play_finished(site_id) <= PlayFinishedMessage | audio_server_backend.publish_play_finished);
         t!(audio_server_all_play_finished_works:
-                    audio_server.subscribe_all_play_finished <= PlayFinishedMessage | audio_server_backend.publish_play_finished
-                    with PlayFinishedMessage { id: "my id".into(), site_id: "some site".into() };
-            );
+                    audio_server.subscribe_all_play_finished <= PlayFinishedMessage | audio_server_backend.publish_play_finished);
         t!(audio_server_audio_frame_works:
                     OneToMany
-                    audio_server.subscribe_audio_frame { "some site".into() } <= AudioFrameMessage | audio_server_backend.publish_audio_frame
-                    with AudioFrameMessage { wav_frame: vec![42; 1000], site_id: "some site".into() };
-            );
+                    audio_server.subscribe_audio_frame(site_id) <= AudioFrameMessage | audio_server_backend.publish_audio_frame);
         t!(audio_server_replay_request:
                     OneToMany
-                    audio_server_backend.subscribe_replay_request { "some site".into() } <= ReplayRequestMessage | audio_server.publish_replay_request
-                    with ReplayRequestMessage { request_id: "some request".into(), start_at_ms: 12, site_id: "some site".into() };
-            );
+                    audio_server_backend.subscribe_replay_request(site_id) <= ReplayRequestMessage | audio_server.publish_replay_request);
         t!(audio_server_replay_response:
                     OneToMany
-                    audio_server.subscribe_replay_response { "some site".into() } <= AudioFrameMessage | audio_server_backend.publish_replay_response
-                    with AudioFrameMessage { wav_frame: vec![42; 1000], site_id: "some site".into() };
-            );
+                    audio_server.subscribe_replay_response(site_id) <= AudioFrameMessage | audio_server_backend.publish_replay_response);
 
         t_component!(dialogue_component: dialogue_backend | dialogue);
         t_toggleable!(dialogue_toggleable: dialogue_backend | dialogue);
         t!(dialogue_session_started_works:
-                    dialogue.subscribe_session_started <= SessionStartedMessage | dialogue_backend.publish_session_started
-                    with SessionStartedMessage { session_id: "some id".into(), custom_data: None, site_id: "some site".into(), reactivated_from_session_id: None };);
+                    dialogue.subscribe_session_started <= SessionStartedMessage | dialogue_backend.publish_session_started);
         t!(dialogue_session_queued_works:
-                    dialogue.subscribe_session_queued <= SessionQueuedMessage | dialogue_backend.publish_session_queued
-                    with SessionQueuedMessage { session_id: "some id".into(), custom_data: None, site_id: "some site".into() };);
+                    dialogue.subscribe_session_queued <= SessionQueuedMessage | dialogue_backend.publish_session_queued);
         t!(dialogue_intents_works:
-                    dialogue.subscribe_intents <= IntentMessage | dialogue_backend.publish_intent
-                    with IntentMessage { site_id: "some site".into(), session_id: "some id".into(), custom_data: None, input: "hello world".into(), asr_tokens: None, asr_confidence: None, intent: NluIntentClassifierResult { intent_name: "my intent".into(), confidence_score: 0.73 }, speaker_hypotheses: None, slots: vec![], alternatives: None };);
+                    dialogue.subscribe_intents <= IntentMessage | dialogue_backend.publish_intent);
         t!(dialogue_intent_works:
                     OneToMany
-                    dialogue.subscribe_intent { "my intent".into() } <= IntentMessage | dialogue_backend.publish_intent
-                    with IntentMessage { site_id: "some site".into(), session_id: "some id".into(), custom_data: None, input: "hello world".into(), asr_tokens: Some(vec![vec![AsrToken { value: "hello".into(), confidence: 1., range_start: 0, range_end: 4, time: AsrDecodingDuration { start: 0.0, end: 2.0 } }, AsrToken { value: "world".into(), confidence: 1., range_start: 5, range_end: 9, time: AsrDecodingDuration { start: 2.0, end: 4.0 } },]]), asr_confidence: Some(0.5),intent: NluIntentClassifierResult { intent_name: "my intent".into(), confidence_score: 0.73 }, speaker_hypotheses: Some(vec![SpeakerId { name: Some("toto".into()), confidence: 0.9}]), slots: vec![], alternatives: Some(vec![hermes::NluIntentAlternative {intent_name: Some("foobar".into()), confidence_score: 0.5, slots:vec![]}, hermes::NluIntentAlternative {intent_name: None, confidence_score: 0.4, slots:vec![]} ]) };);
+                    dialogue.subscribe_intent(intent.intent_name) <= IntentMessage | dialogue_backend.publish_intent);
         t!(dialogue_intent_not_recognized_works:
-                    dialogue.subscribe_intent_not_recognized <= IntentNotRecognizedMessage | dialogue_backend.publish_intent_not_recognized
-                    with IntentNotRecognizedMessage { site_id: "some site".into(), session_id: "some id".into(), custom_data: None, input: Some("hello world".into()), speaker_hypotheses: None, confidence_score: 0.5, alternatives: Some(vec![]) };);
+                    dialogue.subscribe_intent_not_recognized <= IntentNotRecognizedMessage | dialogue_backend.publish_intent_not_recognized);
         t!(dialogue_session_ended_works:
-                    dialogue.subscribe_session_ended <= SessionEndedMessage | dialogue_backend.publish_session_ended
-                    with SessionEndedMessage { site_id: "some site".into(), session_id: "some id".into(), custom_data: None, termination: SessionTerminationType::Nominal };);
+                    dialogue.subscribe_session_ended <= SessionEndedMessage | dialogue_backend.publish_session_ended);
         t!(dialogue_start_session_works:
-                    dialogue_backend.subscribe_start_session <= StartSessionMessage | dialogue.publish_start_session
-                    with StartSessionMessage { init: SessionInit::Action { text: None, intent_filter: None, can_be_enqueued: false, send_intent_not_recognized: true }, custom_data: None, site_id: None };);
+                    dialogue_backend.subscribe_start_session <= StartSessionMessage | dialogue.publish_start_session);
         t!(dialogue_continue_session_works:
-                    dialogue_backend.subscribe_continue_session <= ContinueSessionMessage | dialogue.publish_continue_session
-                    with ContinueSessionMessage { session_id: "some id".into(), text: "some text".into(), intent_filter: None, send_intent_not_recognized: true, custom_data: Some("custom data".into()), slot: Some("some slot".to_string()) };);
+                    dialogue_backend.subscribe_continue_session <= ContinueSessionMessage | dialogue.publish_continue_session);
         t!(dialogue_end_session_works:
-                    dialogue_backend.subscribe_end_session <= EndSessionMessage | dialogue.publish_end_session
-                    with EndSessionMessage { session_id: "some id".into(), text: None };);
+                    dialogue_backend.subscribe_end_session <= EndSessionMessage | dialogue.publish_end_session);
         t!(dialogue_configure_works:
-                    dialogue_backend.subscribe_configure <= DialogueConfigureMessage | dialogue.publish_configure
-                    with DialogueConfigureMessage { site_id: Some("some site".into()), intents: Some(vec![DialogueConfigureIntent { intent_id: "some intent".into(), enable: Some(true)}] )};);
+                    dialogue_backend.subscribe_configure <= DialogueConfigureMessage | dialogue.publish_configure);
 
         t_component!(injection_component: injection_backend | injection);
         t!(injection_request:
-                    injection_backend.subscribe_injection_request <= InjectionRequestMessage | injection.publish_injection_request
-                    with InjectionRequestMessage { operations: vec![], lexicon: std::collections::HashMap::new(), cross_language: None, id: Some("abc".into()) };);
+                    injection_backend.subscribe_injection_request <= InjectionRequestMessage | injection.publish_injection_request);
         t!(injection_status_request:
                     injection_backend.subscribe_injection_status_request <= injection.publish_injection_status_request);
         t!(injection_status:
-                    injection.subscribe_injection_status <= InjectionStatusMessage | injection_backend.publish_injection_status
-                    with InjectionStatusMessage { last_injection_date: Some($crate::now()) };);
+                    injection.subscribe_injection_status <= InjectionStatusMessage | injection_backend.publish_injection_status);
         t!(injection_complete:
-                    injection.subscribe_injection_complete <= InjectionCompleteMessage | injection_backend.publish_injection_complete
-                    with InjectionCompleteMessage { request_id: Some("some id".into()) };);
+                    injection.subscribe_injection_complete <= InjectionCompleteMessage | injection_backend.publish_injection_complete);
         t!(injection_reset_request:
-                    injection_backend.subscribe_injection_reset_request <= InjectionResetRequestMessage | injection.publish_injection_reset_request
-                    with InjectionResetRequestMessage { request_id: Some("abc".into()) };);
+                    injection_backend.subscribe_injection_reset_request <= InjectionResetRequestMessage | injection.publish_injection_reset_request);
         t!(injection_reset_complete:
-                    injection.subscribe_injection_reset_complete <= InjectionResetCompleteMessage | injection_backend.publish_injection_reset_complete
-                    with InjectionResetCompleteMessage { request_id: Some("abc".into()) };);
+                    injection.subscribe_injection_reset_complete <= InjectionResetCompleteMessage | injection_backend.publish_injection_reset_complete);
     };
 }

--- a/hermes-utils-derive/Cargo.toml
+++ b/hermes-utils-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hermes-utils-derive"
+version = "0.1.0"
+authors = ["Thibaut Lorrain <thibaut.lorrain@snips.ai>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0.5"
+quote = "1.0.2"

--- a/hermes-utils-derive/src/lib.rs
+++ b/hermes-utils-derive/src/lib.rs
@@ -37,7 +37,7 @@ fn impl_example_macro(input: &syn::DeriveInput) -> TokenStream {
                 let value = &value.tokens;
                 quote!(#ident: #value.into())
             } else {
-                quote!(#ident: Example::example(hermes_utils::ExampleConfig {
+                quote!(#ident: hermes_utils::Example::example(hermes_utils::ExampleConfig {
                     field_name: Some(stringify!(#ident).into()),
                     .. config.clone()
                 }))

--- a/hermes-utils-derive/src/lib.rs
+++ b/hermes-utils-derive/src/lib.rs
@@ -1,0 +1,58 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+use syn;
+
+use quote::quote;
+
+#[proc_macro_derive(Example, attributes(example_value))]
+pub fn example_derive(token_stream: TokenStream) -> TokenStream {
+    let ast = syn::parse(token_stream).unwrap();
+    impl_example_macro(&ast)
+}
+
+fn impl_example_macro(input: &syn::DeriveInput) -> TokenStream {
+    let struct_name = &input.ident;
+
+    let data = match &input.data {
+        syn::Data::Struct(data) => data,
+        _ => panic!("examples can only be derived for structs"),
+    };
+
+    let fields: Vec<_> = data
+        .fields
+        .iter()
+        .map(|field| {
+            (
+                field.ident.as_ref().expect("field should have and ident"),
+                field
+                    .attrs
+                    .iter()
+                    .find(|attr| attr.path.get_ident().map(|it| it.to_string()) == Some("example_value".into())),
+            )
+        })
+        .map(|(ident, value)| {
+            if let Some(value) = value {
+                let value = &value.tokens;
+                quote!(#ident: #value.into())
+            } else {
+                quote!(#ident: Example::example(hermes_utils::ExampleConfig {
+                    field_name: Some(stringify!(#ident).into()),
+                    .. config.clone()
+                }))
+            }
+        })
+        .collect();
+
+    quote!(
+        impl hermes_utils::Example for # struct_name {
+            fn example(config: hermes_utils::ExampleConfig) -> Self {
+                Self {
+                    # ( # fields, )*
+                }
+            }
+        }
+    )
+    .into()
+}

--- a/hermes-utils/Cargo.toml
+++ b/hermes-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hermes-utils"
+version = "0.1.0"
+authors = ["Thibaut Lorrain <thibaut.lorrain@snips.ai>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hermes-utils-derive = { path="../hermes-utils-derive" }

--- a/hermes-utils/src/lib.rs
+++ b/hermes-utils/src/lib.rs
@@ -1,0 +1,110 @@
+pub use hermes_utils_derive::Example;
+
+#[derive(Default, Clone)]
+pub struct ExampleConfig {
+    pub field_name: Option<String>,
+    pub minimal: bool,
+    pub index: Option<usize>,
+}
+
+/// A trait used to generate example values of the implementing struct.
+pub trait Example: Sized {
+    /// Generate a minimal example (Options are set to None and Vecs are empty)
+    fn minimal_example() -> Self {
+        Self::example(ExampleConfig {
+            minimal: true,
+            ..Default::default()
+        })
+    }
+
+    /// Generate a full example (Options are set to Some and Vecs contain values)
+    fn full_example() -> Self {
+        Self::example(Default::default())
+    }
+
+    /// Generate an example using the given config
+    fn example(config: ExampleConfig) -> Self;
+}
+
+impl Example for String {
+    fn example(config: ExampleConfig) -> Self {
+        match (config.field_name, config.index) {
+            (Some(field_name), Some(index)) => format!("<{} {}>", field_name.replace("_", " "), index),
+            (Some(field_name), None) => format!("<{}>", field_name.replace("_", " ")),
+            (None, Some(index)) => format!("string {}", index),
+            (None, None) => "a string".into(),
+        }
+    }
+}
+
+impl<T: Example> Example for Option<T> {
+    fn example(config: ExampleConfig) -> Self {
+        if config.minimal {
+            None
+        } else {
+            Some(T::example(config))
+        }
+    }
+}
+
+impl<T: Example> Example for Vec<T> {
+    fn example(config: ExampleConfig) -> Self {
+        if config.minimal {
+            vec![]
+        } else {
+            (1..=3)
+                .map(|index| {
+                    T::example(ExampleConfig {
+                        index: Some(index),
+                        ..config.clone()
+                    })
+                })
+                .collect()
+        }
+    }
+}
+
+macro_rules! example_from_default_for {
+    ($typ:ty) => {
+        impl Example for $typ {
+            fn example(_: ExampleConfig) -> Self {
+                Default::default()
+            }
+        }
+    };
+}
+
+example_from_default_for!(i8);
+example_from_default_for!(i16);
+example_from_default_for!(i32);
+example_from_default_for!(i64);
+example_from_default_for!(i128);
+
+example_from_default_for!(u8);
+example_from_default_for!(u16);
+example_from_default_for!(u32);
+example_from_default_for!(u64);
+example_from_default_for!(u128);
+example_from_default_for!(usize);
+
+example_from_default_for!(f32);
+example_from_default_for!(f64);
+
+example_from_default_for!(bool);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn example_string() {
+        assert_eq!("a string", String::example(Default::default()));
+        assert_eq!(
+            "<foo bar>",
+            String::example(ExampleConfig {
+                field_name: Some("foo_bar".into()),
+                ..Default::default()
+            })
+        );
+    }
+}

--- a/hermes-utils/src/lib.rs
+++ b/hermes-utils/src/lib.rs
@@ -1,4 +1,6 @@
 pub use hermes_utils_derive::Example;
+use std::collections::HashMap;
+use std::hash::Hash;
 
 #[derive(Default, Clone)]
 pub struct ExampleConfig {
@@ -58,6 +60,35 @@ impl<T: Example> Example for Vec<T> {
                         index: Some(index),
                         ..config.clone()
                     })
+                })
+                .collect()
+        }
+    }
+}
+
+impl<T: Example, U: Example> Example for (T, U) {
+    fn example(config: ExampleConfig) -> Self {
+        (T::example(config.clone()), U::example(config))
+    }
+}
+
+impl<T: Example + Eq + Hash, U: Example> Example for HashMap<T, U> {
+    fn example(config: ExampleConfig) -> Self {
+        if config.minimal {
+            HashMap::new()
+        } else {
+            (1..=3)
+                .map(|index| {
+                    (
+                        T::example(ExampleConfig {
+                            index: Some(index),
+                            ..config.clone()
+                        }),
+                        U::example(ExampleConfig {
+                            index: Some(index),
+                            ..config.clone()
+                        }),
+                    )
                 })
                 .collect()
         }

--- a/hermes-utils/src/lib.rs
+++ b/hermes-utils/src/lib.rs
@@ -72,10 +72,10 @@ impl<T: Example, U: Example> Example for (T, U) {
     }
 }
 
-impl<T: Example + Eq + Hash, U: Example> Example for HashMap<T, U> {
+impl<T: Example + Eq + Hash, U: Example, S: ::std::hash::BuildHasher + Default> Example for HashMap<T, U, S> {
     fn example(config: ExampleConfig) -> Self {
         if config.minimal {
-            HashMap::new()
+            HashMap::default()
         } else {
             (1..=3)
                 .map(|index| {

--- a/hermes-utils/tests/example_derive.rs
+++ b/hermes-utils/tests/example_derive.rs
@@ -1,0 +1,123 @@
+use hermes_utils::Example;
+
+#[derive(Example, Debug, PartialEq)]
+struct DemoExampleDerive {
+    value_from_name_string: String,
+    #[example_value("hello world")]
+    overridden_string: String,
+    optional_string: Option<String>,
+    zeroed_i32: i32,
+    #[example_value(5)]
+    overridden_i32: i32,
+    false_boolean: bool,
+    #[example_value(true)]
+    overridden_boolean: bool,
+    struct_implementing_example: Option<NumericTypesSupported>,
+    #[example_value(DummyStruct { fizz: Some("buzz".into()) })]
+    struct_implementing_not_example: DummyStruct,
+    vec: Vec<SimpleStruct>,
+    #[example_value(get_example_vec())]
+    overridden_vec: Vec<SimpleStruct>,
+}
+
+#[derive(Example, Debug, PartialEq)]
+struct NumericTypesSupported {
+    default_i8: i8,
+    default_i16: i16,
+    default_i32: i32,
+    default_i64: i64,
+    default_i128: i128,
+    default_u8: u8,
+    default_u16: u16,
+    default_u32: u32,
+    default_u64: u64,
+    default_u128: u128,
+    default_usize: usize,
+    default_f32: f32,
+    default_f64: f64,
+}
+
+#[derive(Example, Debug, PartialEq)]
+struct SimpleStruct {
+    name: String,
+}
+
+#[derive(Debug, PartialEq)]
+struct DummyStruct {
+    fizz: Option<String>,
+}
+
+fn get_example_vec() -> Vec<SimpleStruct> {
+    vec![
+        SimpleStruct { name: "hello".into() },
+        SimpleStruct { name: "world".into() },
+    ]
+}
+
+#[test]
+fn full_example_works() {
+    assert_eq!(
+        DemoExampleDerive::full_example(),
+        DemoExampleDerive {
+            value_from_name_string: "<value from name string>".into(),
+            overridden_string: "hello world".into(),
+            optional_string: Some("<optional string>".into()),
+            struct_implementing_example: Some(NumericTypesSupported {
+                default_i8: 0,
+                default_i16: 0,
+                default_i32: 0,
+                default_i64: 0,
+                default_i128: 0,
+                default_u8: 0,
+                default_u16: 0,
+                default_u32: 0,
+                default_u64: 0,
+                default_u128: 0,
+                default_usize: 0,
+                default_f32: 0.0,
+                default_f64: 0.0,
+            }),
+            zeroed_i32: 0,
+            overridden_i32: 5,
+            false_boolean: false,
+            overridden_boolean: true,
+            struct_implementing_not_example: DummyStruct {
+                fizz: Some("buzz".into())
+            },
+            vec: vec![
+                SimpleStruct {
+                    name: "<name 1>".into()
+                },
+                SimpleStruct {
+                    name: "<name 2>".into()
+                },
+                SimpleStruct {
+                    name: "<name 3>".into()
+                }
+            ],
+            overridden_vec: get_example_vec(),
+        }
+    )
+}
+
+#[test]
+fn minimal_example_works() {
+    assert_eq!(
+        DemoExampleDerive::minimal_example(),
+        DemoExampleDerive {
+            value_from_name_string: "<value from name string>".into(),
+            overridden_string: "hello world".into(),
+            optional_string: None,
+            struct_implementing_example: None,
+            zeroed_i32: 0,
+            overridden_i32: 5,
+            false_boolean: false,
+            overridden_boolean: true,
+            struct_implementing_not_example: DummyStruct {
+                fizz: Some("buzz".into())
+            },
+            vec: vec![],
+            overridden_vec: get_example_vec(),
+        }
+    )
+}

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -16,3 +16,4 @@ semver = { version = "0.9", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+hermes-utils = { path = "../hermes-utils" }

--- a/hermes/src/lib.rs
+++ b/hermes/src/lib.rs
@@ -10,7 +10,7 @@ extern crate serde_json;
 extern crate snips_nlu_ontology;
 
 #[macro_use]
-extern crate hermes_utils;
+pub extern crate hermes_utils;
 
 pub mod errors;
 pub mod ontology;

--- a/hermes/src/lib.rs
+++ b/hermes/src/lib.rs
@@ -9,6 +9,9 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate snips_nlu_ontology;
 
+#[macro_use]
+extern crate hermes_utils;
+
 pub mod errors;
 pub mod ontology;
 

--- a/hermes/src/ontology/asr.rs
+++ b/hermes/src/ontology/asr.rs
@@ -1,6 +1,6 @@
 use super::HermesMessage;
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct AsrStartListeningMessage {
     /// The site that must be listened too
@@ -13,14 +13,14 @@ pub struct AsrStartListeningMessage {
 
 impl<'de> HermesMessage<'de> for AsrStartListeningMessage {}
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct AsrDecodingDuration {
     pub start: f32,
     pub end: f32,
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct AsrToken {
     /// The value of the token
@@ -36,7 +36,7 @@ pub struct AsrToken {
     pub time: AsrDecodingDuration,
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct TextCapturedMessage {
     /// The text captured
@@ -58,7 +58,7 @@ pub struct TextCapturedMessage {
 
 impl<'de> HermesMessage<'de> for TextCapturedMessage {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SpeakerId {
     /// The name of the detected speaker, `None` represents unknown speakers

--- a/hermes/src/ontology/audio_server.rs
+++ b/hermes/src/ontology/audio_server.rs
@@ -124,7 +124,7 @@ pub struct ReplayRequestMessage {
     /// An id for the request, it will be passed back in the replayed frames headers.
     pub request_id: String,
     /// When to start replay from
-    #[example_value(1545696000000i64)]
+    #[example_value(1_545_696_000_000i64)]
     pub start_at_ms: i64,
     /// The site this frame originates from
     pub site_id: String,

--- a/hermes/src/ontology/audio_server.rs
+++ b/hermes/src/ontology/audio_server.rs
@@ -1,7 +1,7 @@
 use super::HermesMessage;
 
 /// This message is used to request the audio server to play a wav file
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct PlayBytesMessage {
     /// An id for the request, it will be passed back in the `PlayFinishedMessage`
@@ -10,6 +10,7 @@ pub struct PlayBytesMessage {
     /// Note that serde json serialization is provided but in practice most handler impl will want
     /// to avoid the base64 encoding/decoding and give this a special treatment
     #[serde(serialize_with = "as_base64", deserialize_with = "from_base64")]
+    #[example_value(vec![0;2048])]
     pub wav_bytes: Vec<u8>,
     /// The site where the bytes should be played
     pub site_id: String,
@@ -18,7 +19,7 @@ pub struct PlayBytesMessage {
 impl<'de> HermesMessage<'de> for PlayBytesMessage {}
 
 /// This message is used to request the audio server to play a part of a sound
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamBytesMessage {
     /// The play request identifier. This identifier will be passed to subsequent chunks along the
@@ -26,6 +27,7 @@ pub struct StreamBytesMessage {
     pub stream_id: String,
     /// The bytes of the chunk to play (should be a regular wav with header)
     #[serde(serialize_with = "as_base64", deserialize_with = "from_base64")]
+    #[example_value(vec![0;256])]
     pub bytes: Vec<u8>,
     /// The site where the audio should be played
     pub site_id: String,
@@ -39,7 +41,7 @@ impl<'de> HermesMessage<'de> for StreamBytesMessage {}
 
 /// This message is used for the audio streaming on the snips platform. It is used both for normal
 /// streaming and replay streaming.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioFrameMessage {
     /// The bytes of the WAV frame (should be a regular WAV with header).
@@ -104,6 +106,7 @@ pub struct AudioFrameMessage {
     /// Note that serde json serialization is provided but in practice most handler impl will want
     /// to avoid the base64 encoding/decoding and give this a special treatment
     #[serde(serialize_with = "as_base64", deserialize_with = "from_base64")]
+    #[example_value(vec![0;512])]
     pub wav_frame: Vec<u8>,
     /// The site this frame originates from
     pub site_id: String,
@@ -115,12 +118,13 @@ impl<'de> HermesMessage<'de> for AudioFrameMessage {}
 /// time. The audio server implementation is expected to be able to replay frames from a few seconds
 /// in the past. Replayed frames go through the same canal as normal frames and are identified by a
 /// special metadata in the INFO chunk
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplayRequestMessage {
     /// An id for the request, it will be passed back in the replayed frames headers.
     pub request_id: String,
     /// When to start replay from
+    #[example_value(1545696000000i64)]
     pub start_at_ms: i64,
     /// The site this frame originates from
     pub site_id: String,
@@ -129,7 +133,7 @@ pub struct ReplayRequestMessage {
 impl<'de> HermesMessage<'de> for ReplayRequestMessage {}
 
 /// This message is send by the audio server when a wav has finished playing
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct PlayFinishedMessage {
     /// The id of the `PlayBytesMessage` which bytes finished playing
@@ -139,7 +143,7 @@ pub struct PlayFinishedMessage {
 }
 
 /// This message is send by the audio server when a audio stream has finished playing
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamFinishedMessage {
     /// The id of the `StreamBytesMessage` which bytes finished playing

--- a/hermes/src/ontology/dialogue.rs
+++ b/hermes/src/ontology/dialogue.rs
@@ -2,8 +2,9 @@ use super::asr::{AsrToken, SpeakerId};
 use super::nlu::{NluIntentClassifierResult, NluSlot};
 use super::HermesMessage;
 use crate::{HermesComponent, NluIntentAlternative};
+use hermes_utils::Example;
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct IntentMessage {
     /// The session in which this intent was detected
@@ -32,7 +33,7 @@ pub struct IntentMessage {
 
 impl<'de> HermesMessage<'de> for IntentMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct IntentNotRecognizedMessage {
     /// The session in which no intent was recognized
@@ -86,7 +87,22 @@ fn boolean_default_true() -> bool {
     true
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+impl Example for SessionInit {
+    fn example(config: hermes_utils::ExampleConfig) -> SessionInit {
+        SessionInit::Action {
+            text: Some("Hello world".into()),
+            intent_filter: if config.minimal {
+                None
+            } else {
+                Some(vec!["HelloResponseIntent".into()])
+            },
+            can_be_enqueued: true,
+            send_intent_not_recognized: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct StartSessionMessage {
     /// The way this session should be created
@@ -102,7 +118,7 @@ pub struct StartSessionMessage {
 
 impl<'de> HermesMessage<'de> for StartSessionMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionStartedMessage {
     /// The id of the session that was started
@@ -119,7 +135,7 @@ pub struct SessionStartedMessage {
 
 impl<'de> HermesMessage<'de> for SessionStartedMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionQueuedMessage {
     /// The id of the session that was queued
@@ -132,7 +148,7 @@ pub struct SessionQueuedMessage {
 
 impl<'de> HermesMessage<'de> for SessionQueuedMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct ContinueSessionMessage {
     /// The id of the session this action applies to
@@ -161,7 +177,7 @@ pub struct ContinueSessionMessage {
 
 impl<'de> HermesMessage<'de> for ContinueSessionMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct EndSessionMessage {
     /// The id of the session to end
@@ -189,7 +205,7 @@ pub enum SessionTerminationType {
     Error { error: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionEndedMessage {
     /// The id of the session that was terminated
@@ -197,6 +213,7 @@ pub struct SessionEndedMessage {
     /// The custom data associated to this session
     pub custom_data: Option<String>,
     /// How the session was ended
+    #[example_value(SessionTerminationType::Nominal)]
     pub termination: SessionTerminationType,
     /// The site on which this session took place
     pub site_id: String,
@@ -204,7 +221,7 @@ pub struct SessionEndedMessage {
 
 impl<'de> HermesMessage<'de> for SessionEndedMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct DialogueConfigureMessage {
     /// The site on which this configuration applies, if None the configuration will be applied to
@@ -216,11 +233,12 @@ pub struct DialogueConfigureMessage {
 
 impl<'de> HermesMessage<'de> for DialogueConfigureMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct DialogueConfigureIntent {
     /// The name of the intent that should be configured.
     pub intent_id: String,
     /// Whether this intent should be activated on not.
+    #[example_value(true)]
     pub enable: Option<bool>,
 }

--- a/hermes/src/ontology/hotword.rs
+++ b/hermes/src/ontology/hotword.rs
@@ -7,7 +7,7 @@ pub enum HotwordModelType {
     Personal,
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct HotwordDetectedMessage {
     /// The site where the hotword was triggered
@@ -18,6 +18,7 @@ pub struct HotwordDetectedMessage {
     pub model_version: Option<String>,
     /// The type of hotword that was triggered
     // TODO make non optional in next major rework of the protocol
+    #[example_value(Some(HotwordModelType::Universal))]
     pub model_type: Option<HotwordModelType>,
     /// The current sensitivity of the detector
     pub current_sensitivity: Option<f32>,

--- a/hermes/src/ontology/injection.rs
+++ b/hermes/src/ontology/injection.rs
@@ -82,7 +82,7 @@ impl<'de> HermesMessage<'de> for InjectionRequestMessage {}
 #[serde(rename_all = "camelCase")]
 pub struct InjectionStatusMessage {
     /// Date of the latest injection
-    #[example_value(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(1545696000, 0), Utc))]
+    #[example_value(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(1_545_696_000, 0), Utc))]
     pub last_injection_date: Option<DateTime<Utc>>,
 }
 

--- a/hermes/src/ontology/injection.rs
+++ b/hermes/src/ontology/injection.rs
@@ -1,7 +1,11 @@
-use super::HermesMessage;
+use std::collections::HashMap;
+
 use chrono::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
+
+use hermes_utils::Example;
+
+use super::HermesMessage;
 
 type Value = String;
 type Entity = String;
@@ -16,7 +20,13 @@ pub enum InjectionKind {
     AddFromVanilla,
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+impl Example for InjectionKind {
+    fn example(_: hermes_utils::ExampleConfig) -> Self {
+        Self::Add
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Example)]
 pub struct EntityValue {
     pub value: String,
     pub weight: u32,
@@ -52,7 +62,7 @@ impl Serialize for EntityValue {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct InjectionRequestMessage {
     /// List of operations to execute in the order of the list on a model
@@ -68,16 +78,17 @@ pub struct InjectionRequestMessage {
 
 impl<'de> HermesMessage<'de> for InjectionRequestMessage {}
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct InjectionStatusMessage {
     /// Date of the latest injection
+    #[example_value(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(1545696000, 0), Utc))]
     pub last_injection_date: Option<DateTime<Utc>>,
 }
 
 impl<'de> HermesMessage<'de> for InjectionStatusMessage {}
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct InjectionCompleteMessage {
     /// The id of the `InjectionRequestMessage`
@@ -86,7 +97,7 @@ pub struct InjectionCompleteMessage {
 
 impl<'de> HermesMessage<'de> for InjectionCompleteMessage {}
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct InjectionResetRequestMessage {
     /// The id of the `InjectionResetRequestMessage`
@@ -95,7 +106,7 @@ pub struct InjectionResetRequestMessage {
 
 impl<'de> HermesMessage<'de> for InjectionResetRequestMessage {}
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct InjectionResetCompleteMessage {
     /// The id of the `InjectionResetCompleteMessage`
@@ -106,8 +117,9 @@ impl<'de> HermesMessage<'de> for InjectionResetCompleteMessage {}
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use serde_json;
+
+    use super::*;
 
     #[test]
     fn custom_deserialization_entityvalue_works() {
@@ -117,7 +129,7 @@ mod test {
             entity_value,
             EntityValue {
                 value: "a".to_string(),
-                weight: 1
+                weight: 1,
             }
         );
 
@@ -127,7 +139,7 @@ mod test {
             entity_value,
             EntityValue {
                 value: "a".to_string(),
-                weight: 42
+                weight: 42,
             }
         );
     }
@@ -156,14 +168,14 @@ mod test {
             values_per_entity["e_0"][0],
             EntityValue {
                 value: "a".to_string(),
-                weight: 1
+                weight: 1,
             }
         );
         assert_eq!(
             values_per_entity["e_0"][1],
             EntityValue {
                 value: "b".to_string(),
-                weight: 42
+                weight: 42,
             }
         );
     }
@@ -182,14 +194,14 @@ mod test {
             values_per_entity["e_0"][0],
             EntityValue {
                 value: "a".to_string(),
-                weight: 22
+                weight: 22,
             }
         );
         assert_eq!(
             values_per_entity["e_0"][1],
             EntityValue {
                 value: "b".to_string(),
-                weight: 31
+                weight: 31,
             }
         );
     }

--- a/hermes/src/ontology/mod.rs
+++ b/hermes/src/ontology/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use hermes_utils::Example;
 use semver;
 use serde::{Deserialize, Serialize};
 
@@ -21,9 +22,9 @@ pub mod nlu;
 pub mod tts;
 pub mod vad;
 
-pub trait HermesMessage<'de>: fmt::Debug + Deserialize<'de> + Serialize {}
+pub trait HermesMessage<'de>: fmt::Debug + Deserialize<'de> + Serialize + Example {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SiteMessage {
     /// The site concerned
@@ -43,16 +44,17 @@ impl Default for SiteMessage {
 
 impl<'de> HermesMessage<'de> for SiteMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct VersionMessage {
     /// The version of the component
+    #[example_value(semver::Version::parse("1.0.0").unwrap())]
     pub version: semver::Version,
 }
 
 impl<'de> HermesMessage<'de> for VersionMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorMessage {
     /// An optional session id if there is a related session
@@ -65,7 +67,7 @@ pub struct ErrorMessage {
 
 impl<'de> HermesMessage<'de> for ErrorMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SiteErrorMessage {
     /// Site on which the error happened.
@@ -109,7 +111,7 @@ where
         .and_then(|string| base64::decode(&string).map_err(|err| Error::custom(err.to_string())))
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentLoadedOnSiteMessage {
     /// Optional id associated to a load/reload operation for a component
@@ -122,7 +124,7 @@ pub struct ComponentLoadedOnSiteMessage {
 
 impl<'de> HermesMessage<'de> for ComponentLoadedOnSiteMessage {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestComponentReloadMessage {
     /// Id associated to a reload request operation of a component
@@ -131,7 +133,7 @@ pub struct RequestComponentReloadMessage {
 
 impl<'de> HermesMessage<'de> for RequestComponentReloadMessage {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentLoadedMessage {
     /// Optional id associated to a load/reload operation for a component

--- a/hermes/src/ontology/nlu.rs
+++ b/hermes/src/ontology/nlu.rs
@@ -102,7 +102,7 @@ impl Example for NluSlot {
                 } else {
                     "value".into()
                 }),
-                range: 0 + config.index.unwrap_or(0) * 10..6 + config.index.unwrap_or(0) * 10,
+                range: (config.index.unwrap_or(0) * 10)..(6 + config.index.unwrap_or(0) * 10),
                 entity: "entity".into(),
                 confidence_score: Some(1.),
                 alternatives: vec![snips_nlu_ontology::SlotValue::Custom(

--- a/hermes/src/ontology/nlu.rs
+++ b/hermes/src/ontology/nlu.rs
@@ -1,7 +1,9 @@
+use hermes_utils::Example;
+
 use super::asr::AsrToken;
 use super::HermesMessage;
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct NluQueryMessage {
     /// The text to run the NLU on
@@ -19,7 +21,7 @@ pub struct NluQueryMessage {
 
 impl<'de> HermesMessage<'de> for NluQueryMessage {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct NluSlotQueryMessage {
     /// The text to run the slot detection on
@@ -39,7 +41,7 @@ pub struct NluSlotQueryMessage {
 
 impl<'de> HermesMessage<'de> for NluSlotQueryMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct NluSlotMessage {
     /// The id of the `NluSlotQueryMessage` that was processed
@@ -56,7 +58,7 @@ pub struct NluSlotMessage {
 
 impl<'de> HermesMessage<'de> for NluSlotMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct NluIntentNotRecognizedMessage {
     /// The id of the `NluQueryMessage` that was processed
@@ -81,7 +83,41 @@ pub struct NluSlot {
     pub nlu_slot: snips_nlu_ontology::Slot,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+impl Example for NluSlot {
+    fn example(config: hermes_utils::ExampleConfig) -> Self {
+        Self {
+            nlu_slot: snips_nlu_ontology::Slot {
+                slot_name: if let Some(index) = config.index {
+                    format!("slot {} name", index)
+                } else {
+                    "slot name".into()
+                },
+                raw_value: if let Some(index) = config.index {
+                    format!("raw value {}", index)
+                } else {
+                    "raw value".into()
+                },
+                value: snips_nlu_ontology::SlotValue::Custom(if let Some(index) = config.index {
+                    format!("value {}", index).into()
+                } else {
+                    "value".into()
+                }),
+                range: 0 + config.index.unwrap_or(0) * 10..6 + config.index.unwrap_or(0) * 10,
+                entity: "entity".into(),
+                confidence_score: Some(1.),
+                alternatives: vec![snips_nlu_ontology::SlotValue::Custom(
+                    if let Some(index) = config.index {
+                        format!("value {} alternative", index).into()
+                    } else {
+                        "value alternative".into()
+                    },
+                )],
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct NluIntentClassifierResult {
     /// Name of the intent that was found
@@ -90,7 +126,7 @@ pub struct NluIntentClassifierResult {
     pub confidence_score: f32,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct NluIntentMessage {
     /// The id of the `NluQueryMessage` that was processed
@@ -110,7 +146,7 @@ pub struct NluIntentMessage {
 
 impl<'de> HermesMessage<'de> for NluIntentMessage {}
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct NluIntentAlternative {
     /// Name of the intent that was found, or None if not intent was recognized

--- a/hermes/src/ontology/tts.rs
+++ b/hermes/src/ontology/tts.rs
@@ -1,9 +1,10 @@
 use super::HermesMessage;
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SayMessage {
     /// The text to say
+    #[example_value("Hello, world!")]
     pub text: String,
     /// The lang to use when saying the `text`, will use en_GB if not provided
     pub lang: Option<String>,
@@ -17,7 +18,7 @@ pub struct SayMessage {
 
 impl<'de> HermesMessage<'de> for SayMessage {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct SayFinishedMessage {
     /// The id of the `SayMessage` which was has been said
@@ -28,7 +29,7 @@ pub struct SayFinishedMessage {
 
 impl<'de> HermesMessage<'de> for SayFinishedMessage {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterSoundMessage {
     /// The sound to register encoded as a wav.

--- a/hermes/src/ontology/vad.rs
+++ b/hermes/src/ontology/vad.rs
@@ -1,6 +1,6 @@
 use super::HermesMessage;
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct VadUpMessage {
     /// The site concerned
@@ -11,7 +11,7 @@ pub struct VadUpMessage {
 
 impl<'de> HermesMessage<'de> for VadUpMessage {}
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Example)]
 #[serde(rename_all = "camelCase")]
 pub struct VadDownMessage {
     /// The site concerned


### PR DESCRIPTION
This PR adds a new trait `Example` and implements it on all hermes messages.

The idea behind this is to be able to generate some example values for the messages. These examples come in two flavours: minimal (with options set to none and collections empty) and full (with value everywhere)

The implementation is done using a derive proc macro which saves us from writing quite a bit of uniteresting code.

These examples values are now used in the hermes tests suite, making it much more readable. A refactor of the various macros used in the tests suite has also been done, cutting quite a bit of repetitive macro code.

This examples could in the future be used in the documentation (for example showing demo JSON for the mqtt impl)
