### PR TITLE
win32: fix path to hermes_mqtt_ffi dll file

### DIFF
--- a/platforms/hermes-javascript/scripts/utils.js
+++ b/platforms/hermes-javascript/scripts/utils.js
@@ -27,7 +27,7 @@ const LIB_NAME = {
     openbsd: 'libhermes_mqtt_ffi',
     darwin: 'libhermes_mqtt_ffi',
     mac:    'libhermes_mqtt_ffi',
-    win32:  'hermes_mqtt_ffi.dll'
+    win32:  'hermes_mqtt_ffi'
 }[process.platform]
 
 const LIB_PATH = baseFolder =>


### PR DESCRIPTION
LIB_NAME->hermes_mqtt_ffi.dll was combined with LIB_EXTENSION->.dll to produce hermes_mqtt_ffi.dll.dll
Removed the extension from the LIB_NAME entry.